### PR TITLE
docs(README): add deployment architecture section

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -78,7 +78,54 @@ graph LR
   end
 ```
 
-## 📝 Contribution Guide
+## 🚢 Deployment
 
-- [handbook](services/handbooks/workspace/docs)
-- [blog](services/handbooks/workspace/blog)
+### Trigger
+
+- PR ラベルまたは `main` への push で `.github/workflows/auto-label--deploy-trigger.yaml` が起動する。
+- `panicboat/deploy-actions/label-resolver` が `workflow-config.yaml` を参照してデプロイ対象を解決する。
+
+### Stacks
+
+| Stack | Path Convention | Tooling |
+|-------|-----------------|---------|
+| Container | `services/{service}/workspace` | Docker → GHCR (`ghcr.io/panicboat/monorepo`)、`ubuntu-24.04-arm` でビルド |
+| Infrastructure | `services/{service}/terragrunt/envs/{environment}` | Terragrunt (AWS OIDC) |
+| Kubernetes | `services/{service}/kubernetes/overlays/{environment}` | Kustomize（Flux CD で reconcile） |
+
+### Environments
+
+`workflow-config.yaml` で定義。現状 `develop` のみ有効で、`staging` / `production` は予約済み（コメントアウト）。
+
+| Environment | AWS Region | AWS Account | Status |
+|-------------|------------|-------------|--------|
+| develop | ap-northeast-1 | 559744160976 | Active |
+| staging | - | - | Reserved |
+| production | - | - | Reserved |
+
+### Pipeline Flow
+
+```mermaid
+flowchart LR
+  Trigger[PR / push main] --> Resolver[label-resolver]
+  Resolver -->|stack: docker| Builder[container-builder<br/>ubuntu-24.04-arm]
+  Resolver -->|stack: terragrunt| Terragrunt[terragrunt-executor<br/>PR は plan / main は apply]
+  Builder --> GHCR[(ghcr.io/panicboat/monorepo)]
+  Terragrunt --> AWS[(AWS)]
+  GHCR --> Flux[Flux CD]
+  Main[Commit on main] --> Flux
+  Flux --> K8s[(Kubernetes)]
+```
+
+### GitOps Sync (Flux CD)
+
+- Flux の `GitRepository` が本リポジトリの `main` ブランチを監視する。
+- `clusters/{environment}/services/{service}/service.yaml` に定義された `Kustomization` が 5 分間隔で `services/{service}/kubernetes/overlays/{environment}` を reconcile する。
+- `nginx` のみ `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` を併用し、Docker Hub を 30 分間隔でポーリングしてイメージタグを自動更新する。
+
+### Related Repositories
+
+- [panicboat/platform](https://github.com/panicboat/platform) — クラスタの bootstrap、共通コンポーネント、OIDC 用 IAM を提供。
+- [panicboat/deploy-actions](https://github.com/panicboat/deploy-actions) — 再利用可能な GitHub Actions (`label-resolver` / `container-builder` / `terragrunt` / `auto-approve`)。
+
+## 📝 Contribution Guide

--- a/README.md
+++ b/README.md
@@ -76,7 +76,54 @@ graph LR
   end
 ```
 
-## 📝 Contribution Guide
+## 🚢 Deployment
 
-- [handbook](services/handbooks/workspace/docs)
-- [blog](services/handbooks/workspace/blog)
+### Trigger
+
+- PR labels or push to `main` activate the pipeline in `.github/workflows/auto-label--deploy-trigger.yaml`.
+- Deployment targets are resolved from labels by `panicboat/deploy-actions/label-resolver` against `workflow-config.yaml`.
+
+### Stacks
+
+| Stack | Path Convention | Tooling |
+|-------|-----------------|---------|
+| Container | `services/{service}/workspace` | Docker → GHCR (`ghcr.io/panicboat/monorepo`), built on `ubuntu-24.04-arm` |
+| Infrastructure | `services/{service}/terragrunt/envs/{environment}` | Terragrunt via AWS OIDC |
+| Kubernetes | `services/{service}/kubernetes/overlays/{environment}` | Kustomize, reconciled by Flux CD |
+
+### Environments
+
+Defined in `workflow-config.yaml`. Only `develop` is active; `staging` / `production` entries are reserved and currently commented out.
+
+| Environment | AWS Region | AWS Account | Status |
+|-------------|------------|-------------|--------|
+| develop | ap-northeast-1 | 559744160976 | Active |
+| staging | - | - | Reserved |
+| production | - | - | Reserved |
+
+### Pipeline Flow
+
+```mermaid
+flowchart LR
+  Trigger[PR / push main] --> Resolver[label-resolver]
+  Resolver -->|stack: docker| Builder[container-builder<br/>ubuntu-24.04-arm]
+  Resolver -->|stack: terragrunt| Terragrunt[terragrunt-executor<br/>plan on PR / apply on main]
+  Builder --> GHCR[(ghcr.io/panicboat/monorepo)]
+  Terragrunt --> AWS[(AWS)]
+  GHCR --> Flux[Flux CD]
+  Main[Commit on main] --> Flux
+  Flux --> K8s[(Kubernetes)]
+```
+
+### GitOps Sync (Flux CD)
+
+- Flux `GitRepository` watches this repo's `main` branch.
+- Per-service `Kustomization` in `clusters/{environment}/services/{service}/service.yaml` reconciles every 5 minutes against `services/{service}/kubernetes/overlays/{environment}`.
+- `nginx` additionally uses `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` to auto-bump image tags from Docker Hub every 30 minutes.
+
+### Related Repositories
+
+- [panicboat/platform](https://github.com/panicboat/platform) — cluster bootstrap, shared components, and IAM for OIDC.
+- [panicboat/deploy-actions](https://github.com/panicboat/deploy-actions) — reusable GitHub Actions: `label-resolver`, `container-builder`, `terragrunt`, `auto-approve`.
+
+## 📝 Contribution Guide


### PR DESCRIPTION
## Summary

- README.md / README-ja.md の両方に `## 🚢 Deployment` セクションを追記
- Trigger / Stacks / Environments / Pipeline Flow (mermaid) / GitOps Sync / Related Repositories を記載
- 既存の英語/日本語ペア構成を維持

## Test plan

- [ ] GitHub 上で README.md と README-ja.md のレンダリングを目視確認
- [ ] mermaid 図が崩れていないか確認
- [ ] 英語版と日本語版の構造・セクション数が一致しているか確認