### PR TITLE
docs(specs): add kubernetes diff in deploy trigger design

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -92,6 +92,26 @@ jobs:
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+  deploy-kubernetes:
+    name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
+    needs: deploy-trigger
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.deploy-trigger.outputs.has-targets == 'true' &&
+      contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
+      fail-fast: false
+    uses: ./.github/workflows/reusable--kubernetes-executor.yaml
+    with:
+      service-name: ${{ matrix.target.service }}
+      environment: ${{ matrix.target.environment }}
+      working-directory: ${{ matrix.target.stack == 'kubernetes' && matrix.target.working_directory || '' }}
+      app-id: ${{ vars.APP_ID }}
+    secrets:
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
   # cleanup-container:
   #   name: 'Cleanup Container'
   #   needs: deploy-trigger

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -133,7 +133,7 @@ jobs:
 
   deployment-summary:
     name: 'Deployment Summary'
-    needs: [deploy-trigger, deploy-terragrunt, deploy-container]
+    needs: [deploy-trigger, deploy-terragrunt, deploy-container, deploy-kubernetes]
     if: always() && needs.deploy-trigger.outputs.has-targets == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -147,4 +147,5 @@ jobs:
           echo "Targets: ${{ needs.deploy-trigger.outputs.targets }}"
           echo "Terragrunt Job Status: ${{ needs.deploy-terragrunt.result }}"
           echo "Container Job Status: ${{ needs.deploy-container.result }}"
+          echo "Kubernetes Job Status: ${{ needs.deploy-kubernetes.result }}"
           echo "Cleanup Job Status: ${{ needs.cleanup-container.result }}"

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -113,3 +113,36 @@ jobs:
           else
             echo "no-diff=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Compose diff comment
+        id: compose
+        env:
+          NO_DIFF: ${{ steps.dyff.outputs.no-diff }}
+          SERVICE: ${{ inputs.service-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          WORKING_DIR: ${{ inputs.working-directory }}
+        run: |
+          {
+            echo "### Kubernetes Diff: \`${SERVICE}\` (\`${ENVIRONMENT}\`)"
+            echo ""
+            echo "Overlay: \`${WORKING_DIR}\`"
+            echo ""
+            if [ "$NO_DIFF" = "true" ]; then
+              echo "差分なし"
+            else
+              echo "<details><summary>kustomize build diff (dyff between)</summary>"
+              echo ""
+              echo '```diff'
+              cat diff.txt
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+          } > comment.md
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
+        with:
+          header: kubernetes-diff-${{ inputs.service-name }}-${{ inputs.environment }}
+          path: comment.md
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -54,3 +54,16 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install kustomize
+        run: |
+          curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 5.4.3 /usr/local/bin
+          kustomize version
+
+      - name: Install dyff
+        env:
+          DYFF_VERSION: '1.11.3'
+        run: |
+          curl -sSL "https://github.com/homeport/dyff/releases/download/v${DYFF_VERSION}/dyff_${DYFF_VERSION}_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin dyff
+          sudo chmod +x /usr/local/bin/dyff
+          dyff version

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -33,5 +33,24 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Placeholder
-        run: echo "kubernetes-diff for ${{ inputs.service-name }}:${{ inputs.environment }}"
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.1.1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.private-key }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout PR base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -67,3 +67,31 @@ jobs:
           curl -sSL "https://github.com/homeport/dyff/releases/download/v${DYFF_VERSION}/dyff_${DYFF_VERSION}_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin dyff
           sudo chmod +x /usr/local/bin/dyff
           dyff version
+
+      - name: Build kustomize manifests (base)
+        id: build-base
+        run: |
+          if [ -d "base/${{ inputs.working-directory }}" ]; then
+            if ! kustomize build "base/${{ inputs.working-directory }}" > base.yaml 2> _kustomize_base.log; then
+              echo "build-failed=true" >> "$GITHUB_OUTPUT"
+              cat _kustomize_base.log
+              exit 1
+            fi
+          else
+            echo "Overlay not present in base ref; treating as empty."
+            : > base.yaml
+          fi
+
+      - name: Build kustomize manifests (head)
+        id: build-head
+        run: |
+          if [ -d "head/${{ inputs.working-directory }}" ]; then
+            if ! kustomize build "head/${{ inputs.working-directory }}" > head.yaml 2> _kustomize_head.log; then
+              echo "build-failed=true" >> "$GITHUB_OUTPUT"
+              cat _kustomize_head.log
+              exit 1
+            fi
+          else
+            echo "Overlay not present in head ref; treating as empty."
+            : > head.yaml
+          fi

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -109,7 +109,7 @@ jobs:
             cat _dyff.log
             exit "$status"
           fi
-          if [ ! -s diff.txt ]; then
+          if ! grep -q '[^[:space:]]' diff.txt; then
             echo "no-diff=true" >> "$GITHUB_OUTPUT"
           else
             echo "no-diff=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -95,3 +95,21 @@ jobs:
             echo "Overlay not present in head ref; treating as empty."
             : > head.yaml
           fi
+
+      - name: Run dyff between
+        id: dyff
+        run: |
+          set +e
+          dyff between --omit-header --color off base.yaml head.yaml > diff.txt 2> _dyff.log
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "dyff-failed=true" >> "$GITHUB_OUTPUT"
+            cat _dyff.log
+            exit "$status"
+          fi
+          if [ ! -s diff.txt ]; then
+            echo "no-diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no-diff=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -146,3 +146,16 @@ jobs:
           header: kubernetes-diff-${{ inputs.service-name }}-${{ inputs.environment }}
           path: comment.md
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Post failure comment
+        if: failure() && (steps.build-base.outputs.build-failed == 'true' || steps.build-head.outputs.build-failed == 'true' || steps.dyff.outputs.dyff-failed == 'true')
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
+        with:
+          header: kubernetes-diff-${{ inputs.service-name }}-${{ inputs.environment }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          message: |
+            ### Kubernetes Diff: `${{ inputs.service-name }}` (`${{ inputs.environment }}`)
+
+            Overlay: `${{ inputs.working-directory }}`
+
+            kustomize build または dyff の実行に失敗しました。Actions ログで詳細を確認してください: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -56,9 +56,11 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install kustomize
+        env:
+          KUSTOMIZE_VERSION: '5.4.3'
         run: |
           sudo rm -f /usr/local/bin/kustomize
-          curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 5.4.3 /usr/local/bin
+          curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s "${KUSTOMIZE_VERSION}" /usr/local/bin
           kustomize version
 
       - name: Install dyff
@@ -116,7 +118,6 @@ jobs:
           fi
 
       - name: Compose diff comment
-        id: compose
         env:
           NO_DIFF: ${{ steps.dyff.outputs.no-diff }}
           SERVICE: ${{ inputs.service-name }}
@@ -148,15 +149,26 @@ jobs:
           path: comment.md
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      - name: Compose failure comment
+        if: failure() && (steps.build-base.outputs.build-failed == 'true' || steps.build-head.outputs.build-failed == 'true' || steps.dyff.outputs.dyff-failed == 'true')
+        env:
+          SERVICE: ${{ inputs.service-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          WORKING_DIR: ${{ inputs.working-directory }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "### Kubernetes Diff: \`${SERVICE}\` (\`${ENVIRONMENT}\`)"
+            echo ""
+            echo "Overlay: \`${WORKING_DIR}\`"
+            echo ""
+            echo "kustomize build または dyff の実行に失敗しました。Actions ログで詳細を確認してください: ${RUN_URL}"
+          } > comment.md
+
       - name: Post failure comment
         if: failure() && (steps.build-base.outputs.build-failed == 'true' || steps.build-head.outputs.build-failed == 'true' || steps.dyff.outputs.dyff-failed == 'true')
         uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: kubernetes-diff-${{ inputs.service-name }}-${{ inputs.environment }}
+          path: comment.md
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          message: |
-            ### Kubernetes Diff: `${{ inputs.service-name }}` (`${{ inputs.environment }}`)
-
-            Overlay: `${{ inputs.working-directory }}`
-
-            kustomize build または dyff の実行に失敗しました。Actions ログで詳細を確認してください: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -1,0 +1,37 @@
+name: 'Reusable - Kubernetes Executor'
+
+on:
+  workflow_call:
+    inputs:
+      service-name:
+        required: true
+        type: string
+        description: 'Service name (e.g. monolith)'
+      environment:
+        required: true
+        type: string
+        description: 'Environment name (develop, staging, production, etc.)'
+      working-directory:
+        required: true
+        type: string
+        description: 'Path to kustomize overlay (e.g. services/monolith/kubernetes/overlays/develop)'
+      app-id:
+        required: true
+        type: string
+        description: 'GitHub App ID for authentication'
+    secrets:
+      private-key:
+        required: true
+        description: 'GitHub App private key for authentication'
+
+jobs:
+  kubernetes-diff:
+    name: 'Kubernetes Diff'
+    if: inputs.working-directory != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Placeholder
+        run: echo "kubernetes-diff for ${{ inputs.service-name }}:${{ inputs.environment }}"

--- a/.github/workflows/reusable--kubernetes-executor.yaml
+++ b/.github/workflows/reusable--kubernetes-executor.yaml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Install kustomize
         run: |
+          sudo rm -f /usr/local/bin/kustomize
           curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 5.4.3 /usr/local/bin
           kustomize version
 

--- a/docs/superpowers/plans/2026-04-20-kubernetes-diff-in-deploy-trigger.md
+++ b/docs/superpowers/plans/2026-04-20-kubernetes-diff-in-deploy-trigger.md
@@ -1,0 +1,515 @@
+# Kubernetes Diff in Deploy Trigger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `auto-label--deploy-trigger.yaml` に `deploy-kubernetes` ジョブを追加し、PR ブランチ vs base ブランチの kustomize build 出力差分を `dyff between` で生成して PR に sticky comment で表示する。
+
+**Architecture:** caller の `auto-label--deploy-trigger.yaml` が matrix を展開し、各 (service × environment) ごとに新規 reusable workflow `reusable--kubernetes-executor.yaml` を呼び出す。reusable 側で base/head を別ディレクトリに checkout → kustomize build → dyff between → sticky comment 投稿。`pull_request` イベントのみ。
+
+**Tech Stack:** GitHub Actions (reusable workflow / matrix), kustomize, [homeport/dyff](https://github.com/homeport/dyff) v1.11.3, [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) v3.0.4, [actions/create-github-app-token](https://github.com/actions/create-github-app-token) v3.1.1.
+
+**Spec:** [docs/superpowers/specs/2026-04-19-kubernetes-diff-in-deploy-trigger-design.md](../specs/2026-04-19-kubernetes-diff-in-deploy-trigger-design.md)
+
+**Testing notes:** GitHub Actions workflow に unit test は無い。検証手段は次の 2 段:
+1. **構文検証** — actionlint を docker 経由で実行 (`docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/<file>`)
+2. **動作検証** — 本 PR を push して、kubernetes overlay に小さな差分を加え、`deploy-kubernetes` ジョブが期待通り発火し sticky comment が投稿されることを目視確認
+
+## File Structure
+
+| Path | 役割 |
+|---|---|
+| `.github/workflows/reusable--kubernetes-executor.yaml` (新規) | (service, environment) を受け取り、kustomize build → dyff between → PR コメントを実行する reusable workflow |
+| `.github/workflows/auto-label--deploy-trigger.yaml` (変更) | `deploy-kubernetes` ジョブの追加と `deployment-summary` ジョブの `needs` / ログ更新 |
+
+---
+
+### Task 1: reusable workflow のスケルトン作成
+
+inputs / secrets / no-op guard だけを持つ最小の workflow_call ファイルを作る。空 YAML を一度 actionlint で通してから、後続タスクでステップを足していく。
+
+**Files:**
+- Create: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: ファイルを作成し以下の内容で書き込む**
+
+```yaml
+name: 'Reusable - Kubernetes Executor'
+
+on:
+  workflow_call:
+    inputs:
+      service-name:
+        required: true
+        type: string
+        description: 'Service name (e.g. monolith)'
+      environment:
+        required: true
+        type: string
+        description: 'Environment name (develop, staging, production, etc.)'
+      working-directory:
+        required: true
+        type: string
+        description: 'Path to kustomize overlay (e.g. services/monolith/kubernetes/overlays/develop)'
+      app-id:
+        required: true
+        type: string
+        description: 'GitHub App ID for authentication'
+    secrets:
+      private-key:
+        required: true
+        description: 'GitHub App private key for authentication'
+
+jobs:
+  kubernetes-diff:
+    name: 'Kubernetes Diff'
+    if: inputs.working-directory != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Placeholder
+        run: echo "kubernetes-diff for ${{ inputs.service-name }}:${{ inputs.environment }}"
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0、エラー出力なし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): add reusable kubernetes executor skeleton"
+```
+
+---
+
+### Task 2: GitHub App トークン生成と base/head の checkout を追加
+
+PR HEAD と PR BASE をそれぞれ `head/`, `base/` ディレクトリに checkout する。Token は `actions/create-github-app-token@v3.1.1` で生成（既存 reusable と同じバージョン）。
+
+**Files:**
+- Modify: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: Placeholder ステップを下記で置き換える**
+
+```yaml
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.1.1
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.private-key }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout PR base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          token: ${{ steps.app-token.outputs.token }}
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): checkout PR head and base in kubernetes executor"
+```
+
+---
+
+### Task 3: kustomize と dyff のインストールステップを追加
+
+両ツールとも公式 release バイナリを `/usr/local/bin` に配置する。バージョンは plan 作成時点の最新を pin する（renovate 配下の更新は対象外でよい — GitHub Actions YAML 内の bash でのバイナリインストールなので）。
+
+**Files:**
+- Modify: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: checkout の後に kustomize / dyff インストールステップを追加**
+
+`Checkout PR base` ステップの後に以下を追記する:
+
+```yaml
+      - name: Install kustomize
+        run: |
+          curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 5.4.3 /usr/local/bin
+          kustomize version
+
+      - name: Install dyff
+        env:
+          DYFF_VERSION: '1.11.3'
+        run: |
+          curl -sSL "https://github.com/homeport/dyff/releases/download/v${DYFF_VERSION}/dyff_${DYFF_VERSION}_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin dyff
+          sudo chmod +x /usr/local/bin/dyff
+          dyff version
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): install kustomize and dyff in kubernetes executor"
+```
+
+---
+
+### Task 4: kustomize build を base/head それぞれで実行
+
+overlay 不在時（新規追加 PR で base 側に存在しない、削除 PR で head 側に存在しない）は空ファイルを生成する。エラー出力は `_kustomize_*.log` に保存して後続のエラーコメント用に保持する。
+
+**Files:**
+- Modify: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: dyff インストールステップの後に kustomize build ステップを追加**
+
+```yaml
+      - name: Build kustomize manifests (base)
+        id: build-base
+        run: |
+          if [ -d "base/${{ inputs.working-directory }}" ]; then
+            if ! kustomize build "base/${{ inputs.working-directory }}" > base.yaml 2> _kustomize_base.log; then
+              echo "build-failed=true" >> "$GITHUB_OUTPUT"
+              cat _kustomize_base.log
+              exit 1
+            fi
+          else
+            echo "Overlay not present in base ref; treating as empty."
+            : > base.yaml
+          fi
+
+      - name: Build kustomize manifests (head)
+        id: build-head
+        run: |
+          if [ -d "head/${{ inputs.working-directory }}" ]; then
+            if ! kustomize build "head/${{ inputs.working-directory }}" > head.yaml 2> _kustomize_head.log; then
+              echo "build-failed=true" >> "$GITHUB_OUTPUT"
+              cat _kustomize_head.log
+              exit 1
+            fi
+          else
+            echo "Overlay not present in head ref; treating as empty."
+            : > head.yaml
+          fi
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): run kustomize build for base and head refs"
+```
+
+---
+
+### Task 5: dyff between を実行して diff.txt を生成
+
+差分が無いケースを `_no_diff` フラグで検出し、後続のコメント整形で分岐できるようにする。`dyff between --omit-header --no-table-style` でヘッダ行を抑制（PR コメント整形時にこちら側でヘッダを書く）。
+
+**Files:**
+- Modify: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: kustomize build ステップの後に dyff ステップを追加**
+
+```yaml
+      - name: Run dyff between
+        id: dyff
+        run: |
+          set +e
+          dyff between --omit-header --color off base.yaml head.yaml > diff.txt 2> _dyff.log
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "dyff-failed=true" >> "$GITHUB_OUTPUT"
+            cat _dyff.log
+            exit "$status"
+          fi
+          if [ ! -s diff.txt ]; then
+            echo "no-diff=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no-diff=false" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): run dyff between base and head manifests"
+```
+
+---
+
+### Task 6: 成功時の sticky PR コメント投稿
+
+差分の有無で本文を分岐:
+- 差分あり: `<details>` で折りたたんだ code block の中に diff を埋め込む
+- 差分なし: `差分なし` と表記
+
+header は `kubernetes-diff-{service}-{environment}` でジョブ間衝突を防ぐ。
+
+**Files:**
+- Modify: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: dyff ステップの後にコメント整形と投稿ステップを追加**
+
+```yaml
+      - name: Compose diff comment
+        id: compose
+        env:
+          NO_DIFF: ${{ steps.dyff.outputs.no-diff }}
+          SERVICE: ${{ inputs.service-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          WORKING_DIR: ${{ inputs.working-directory }}
+        run: |
+          {
+            echo "### Kubernetes Diff: \`${SERVICE}\` (\`${ENVIRONMENT}\`)"
+            echo ""
+            echo "Overlay: \`${WORKING_DIR}\`"
+            echo ""
+            if [ "$NO_DIFF" = "true" ]; then
+              echo "差分なし"
+            else
+              echo "<details><summary>kustomize build diff (dyff between)</summary>"
+              echo ""
+              echo '```diff'
+              cat diff.txt
+              echo '```'
+              echo ""
+              echo "</details>"
+            fi
+          } > comment.md
+
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
+        with:
+          header: kubernetes-diff-${{ inputs.service-name }}-${{ inputs.environment }}
+          path: comment.md
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): post sticky comment with kubernetes diff"
+```
+
+---
+
+### Task 7: 失敗時のエラーコメント投稿
+
+kustomize / dyff のいずれかが失敗した場合、ジョブは失敗扱いにしつつ、エラー内容を sticky comment にも反映する。`if: failure()` ステップで対応する。
+
+**Files:**
+- Modify: `.github/workflows/reusable--kubernetes-executor.yaml`
+
+- [ ] **Step 1: 既存の `Post sticky comment` ステップの後にエラーコメントステップを追加**
+
+```yaml
+      - name: Post failure comment
+        if: failure() && (steps.build-base.outputs.build-failed == 'true' || steps.build-head.outputs.build-failed == 'true' || steps.dyff.outputs.dyff-failed == 'true')
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
+        with:
+          header: kubernetes-diff-${{ inputs.service-name }}-${{ inputs.environment }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          message: |
+            ### Kubernetes Diff: `${{ inputs.service-name }}` (`${{ inputs.environment }}`)
+
+            Overlay: `${{ inputs.working-directory }}`
+
+            kustomize build または dyff の実行に失敗しました。Actions ログで詳細を確認してください: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/reusable--kubernetes-executor.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/reusable--kubernetes-executor.yaml
+git commit -s -m "feat(ci): post failure comment when kustomize or dyff fails"
+```
+
+---
+
+### Task 8: `auto-label--deploy-trigger.yaml` に `deploy-kubernetes` ジョブを追加
+
+既存 `deploy-container` ジョブの後ろに、kubernetes stack 用 matrix ジョブを挿入する。`deploy-terragrunt` と同形だが apply の概念がないため `event_name == 'pull_request'` ガードを追加する。
+
+**Files:**
+- Modify: `.github/workflows/auto-label--deploy-trigger.yaml:77-93` (`deploy-container` ジョブ末尾の直後に挿入)
+
+- [ ] **Step 1: `deploy-container` ジョブと `cleanup-container` のコメント行の間に新規ジョブを挿入**
+
+`auto-label--deploy-trigger.yaml` の `deploy-container` ジョブの末尾（93 行目: `private-key: ${{ secrets.APP_PRIVATE_KEY }}`）と、コメントアウトされた `cleanup-container` ブロックの間に以下を挿入する:
+
+```yaml
+  deploy-kubernetes:
+    name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
+    needs: deploy-trigger
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.deploy-trigger.outputs.has-targets == 'true' &&
+      contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
+      fail-fast: false
+    uses: ./.github/workflows/reusable--kubernetes-executor.yaml
+    with:
+      service-name: ${{ matrix.target.service }}
+      environment: ${{ matrix.target.environment }}
+      working-directory: ${{ matrix.target.stack == 'kubernetes' && matrix.target.working_directory || '' }}
+      app-id: ${{ vars.APP_ID }}
+    secrets:
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+- [ ] **Step 2: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/auto-label--deploy-trigger.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/auto-label--deploy-trigger.yaml
+git commit -s -m "feat(ci): add deploy-kubernetes job to deploy-trigger workflow"
+```
+
+---
+
+### Task 9: `deployment-summary` ジョブの更新
+
+`needs` に `deploy-kubernetes` を追加し、サマリログに kubernetes ジョブの結果を出力する。
+
+**Files:**
+- Modify: `.github/workflows/auto-label--deploy-trigger.yaml:114-131` (`deployment-summary` ジョブ全体)
+
+- [ ] **Step 1: `deployment-summary` の `needs` 行を更新**
+
+旧:
+```yaml
+    needs: [deploy-trigger, deploy-terragrunt, deploy-container]
+```
+
+新:
+```yaml
+    needs: [deploy-trigger, deploy-terragrunt, deploy-container, deploy-kubernetes]
+```
+
+- [ ] **Step 2: サマリログ出力に kubernetes 行を追加**
+
+旧:
+```yaml
+          echo "Terragrunt Job Status: ${{ needs.deploy-terragrunt.result }}"
+          echo "Container Job Status: ${{ needs.deploy-container.result }}"
+          echo "Cleanup Job Status: ${{ needs.cleanup-container.result }}"
+```
+
+新:
+```yaml
+          echo "Terragrunt Job Status: ${{ needs.deploy-terragrunt.result }}"
+          echo "Container Job Status: ${{ needs.deploy-container.result }}"
+          echo "Kubernetes Job Status: ${{ needs.deploy-kubernetes.result }}"
+          echo "Cleanup Job Status: ${{ needs.cleanup-container.result }}"
+```
+
+- [ ] **Step 3: actionlint で構文検証**
+
+Run: `docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest .github/workflows/auto-label--deploy-trigger.yaml`
+Expected: 終了コード 0
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add .github/workflows/auto-label--deploy-trigger.yaml
+git commit -s -m "feat(ci): include deploy-kubernetes in deployment summary"
+```
+
+---
+
+### Task 10: 動作検証（test PR で発火させる）
+
+実装 PR を push し、kubernetes overlay に小さな差分（コメント追加など）を加えて `deploy-kubernetes` ジョブの発火と sticky comment の投稿を目視で確認する。
+
+**Files:** （検証専用の一時的な編集 — 検証完了後に revert する）
+- Modify: `services/monolith/kubernetes/overlays/develop/kustomization.yaml`
+
+- [ ] **Step 1: 検証用の差分を作る**
+
+```bash
+# 例: 末尾にコメント追加
+echo "# Test diff for deploy-kubernetes verification" >> services/monolith/kubernetes/overlays/develop/kustomization.yaml
+git add services/monolith/kubernetes/overlays/develop/kustomization.yaml
+git commit -s -m "test(ci): trigger deploy-kubernetes for verification"
+git push
+```
+
+- [ ] **Step 2: GitHub Actions の挙動確認**
+
+Run: `gh run list --workflow=auto-label--deploy-trigger.yaml --branch claude/naughty-lewin-746ccf --limit 3`
+
+確認:
+- `deploy-kubernetes (monolith:develop)` ジョブが起動している
+- 他の matrix ペア（kubernetes 以外）は no-op で skip されている
+- ジョブ全体が success で終わっている
+
+- [ ] **Step 3: PR 上で sticky comment を確認**
+
+`gh pr view 525 --comments` または GitHub UI で:
+- `### Kubernetes Diff: monolith (develop)` を含む sticky comment が投稿されている
+- diff 内容が `<details>` 折りたたみ内に表示されている
+- 再 push 後はコメントが上書き更新される（複数コメントが並ばない）
+
+- [ ] **Step 4: 検証用差分を revert**
+
+```bash
+git revert HEAD --no-edit
+git push
+```
+
+revert 後の PR コメントが「差分なし」（または overlay 全体の add/del 状態に応じた表示）に sticky 更新されることを確認する。
+
+- [ ] **Step 5: 検証完了をコミット履歴で確認**
+
+Run: `git log --oneline -10`
+Expected: feat(ci) コミット 7 つ + test(ci) と revert の 2 つが並んでいる

--- a/docs/superpowers/specs/2026-04-19-kubernetes-diff-in-deploy-trigger-design.md
+++ b/docs/superpowers/specs/2026-04-19-kubernetes-diff-in-deploy-trigger-design.md
@@ -1,0 +1,134 @@
+# Kubernetes Diff in Deploy Trigger
+
+## Goal
+
+`auto-label--deploy-trigger.yaml` に Kubernetes 用ジョブを追加し、PR 上で kustomize マニフェストの差分を表示する。terragrunt plan と同等の「変更前後の確認手段」を kubernetes overlay にも提供する。
+
+## Scope
+
+- **対象**: `pull_request` イベントのみ。`push to main` 時は何もしない。
+- **比較**: PR ブランチの `kustomize build` 出力 vs base ブランチの `kustomize build` 出力（テキスト差分）。
+- **クラスタアクセス不要**: 実クラスタへの apply / `kubectl diff` は行わない。
+- **コメント粒度**: 1 PR コメント = 1 (service × environment)。
+- **コメント方式**: Sticky comment（同 key で上書き）。
+- **実装場所**: 当面このリポジトリ内の reusable workflow に inline 実装。`panicboat/deploy-actions` への切り出しは将来の課題。
+
+## Non-Goals
+
+- 実クラスタへの apply / sync 自動化
+- ArgoCD 等 GitOps ツールとの連携
+- Helm / kustomize plugin のサポート（現状の overlay は plain kustomize のみ）
+- `panicboat/deploy-actions` への action 追加
+
+## Architecture
+
+```
+auto-label--deploy-trigger.yaml
+├── deploy-trigger    (既存) — label-resolver で targets 算出
+├── deploy-terragrunt (既存) → reusable--terragrunt-executor.yaml
+├── deploy-container  (既存) → reusable--container-builder.yaml
+├── deploy-kubernetes (新規) → reusable--kubernetes-executor.yaml
+└── deployment-summary (更新) — deploy-kubernetes も needs に追加
+```
+
+既存 3 ジョブと対称な構造を採る。matrix 展開は caller (`auto-label--deploy-trigger.yaml`) 側で行い、reusable workflow は単一の `(service, environment)` を受け取る。
+
+## Components
+
+### 1. `auto-label--deploy-trigger.yaml` の `deploy-kubernetes` ジョブ（新規）
+
+```yaml
+deploy-kubernetes:
+  name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
+  needs: deploy-trigger
+  if: |
+    github.event_name == 'pull_request' &&
+    needs.deploy-trigger.outputs.has-targets == 'true' &&
+    contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
+  strategy:
+    matrix:
+      target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
+    fail-fast: false
+  uses: ./.github/workflows/reusable--kubernetes-executor.yaml
+  with:
+    service-name: ${{ matrix.target.service }}
+    environment: ${{ matrix.target.environment }}
+    working-directory: ${{ matrix.target.stack == 'kubernetes' && matrix.target.working_directory || '' }}
+    app-id: ${{ vars.APP_ID }}
+  secrets:
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+`working-directory` が空文字列の場合 reusable 側で no-op となるガードを設ける（`deploy-container` の `image-name` 空文字列ガードと同パターン）。
+
+### 2. `reusable--kubernetes-executor.yaml`（新規）
+
+#### Inputs
+
+| input | type | required | 説明 |
+|---|---|---|---|
+| `service-name` | string | yes | 例: `monolith` |
+| `environment` | string | yes | 例: `develop` |
+| `working-directory` | string | yes | 例: `services/monolith/kubernetes/overlays/develop` |
+| `app-id` | string | yes | GitHub App ID |
+
+#### Secrets
+
+| secret | required | 説明 |
+|---|---|---|
+| `private-key` | yes | GitHub App private key |
+
+#### ジョブステップ
+
+1. **GitHub App トークン生成** — `actions/create-github-app-token@v3.1.1`
+2. **PR 情報取得** — `jwalton/gh-find-current-pr@v1`
+3. **PR HEAD checkout** — `actions/checkout@v4` を `path: head` で実行（`ref: ${{ github.event.pull_request.head.sha }}`）
+4. **base ref checkout** — `actions/checkout@v4` を `path: base` で実行（`ref: ${{ github.event.pull_request.base.sha }}`）
+5. **kustomize インストール** — 公式インストールスクリプトまたは `setup-kustomize` action
+6. **dyff インストール** — `homeport/dyff` の release バイナリをダウンロード
+7. **base マニフェスト生成** — `kustomize build base/{working-directory} > base.yaml`。overlay 不在時は空ファイル化
+8. **head マニフェスト生成** — `kustomize build head/{working-directory} > head.yaml`。overlay 不在時は空ファイル化
+9. **dyff 実行** — `dyff between --omit-header base.yaml head.yaml > diff.txt`
+10. **PR コメント投稿** — `marocchino/sticky-pull-request-comment@v2`
+    - `header: kubernetes-diff-{service-name}-{environment}`
+    - `message`: diff 内容を `<details>` 折りたたみ込みの Markdown で整形
+
+#### `working-directory == ''` の no-op
+
+ジョブレベル `if: inputs.working-directory != ''` を付与し、空入力時は何もしない。
+
+## Data Flow
+
+```
+PR push
+  → label-dispatcher が stack ラベルを付与
+  → deploy-trigger が label-resolver で targets JSON を生成
+  → deploy-kubernetes ジョブが matrix 展開（kubernetes 以外は no-op）
+  → reusable--kubernetes-executor.yaml が
+      base/head の kustomize build を実行
+      → dyff between で意味的差分を抽出
+      → PR にコメント投稿（sticky）
+```
+
+## Error Handling
+
+| ケース | 挙動 |
+|---|---|
+| base に overlay 不在（新規追加 PR） | `base.yaml` を空にし、全リソースが追加扱いの diff |
+| head に overlay 不在（削除 PR） | `head.yaml` を空にし、全リソースが削除扱いの diff |
+| 差分ゼロ | "差分なし" の旨を sticky comment に投稿（履歴可視化のため） |
+| `kustomize build` がエラー | ジョブを失敗させ、エラー出力を sticky comment に投稿 |
+| `dyff` がエラー | ジョブを失敗させ、stderr を sticky comment に投稿 |
+
+`fail-fast: false` により他 (service × env) の diff は止まらず継続する。
+
+## `deployment-summary` の変更
+
+- `needs` に `deploy-kubernetes` を追加
+- ログ行に `Kubernetes Job Status: ${{ needs.deploy-kubernetes.result }}` を追加
+
+## Future Work
+
+- `panicboat/deploy-actions/kubernetes-executor` action として切り出し、reusable workflow から呼び出す形にリファクタ
+- 実クラスタへの `kubectl apply` / `kubectl diff` 連携（push to main 時の自動 sync）
+- helm chart や kustomize plugin を使う overlay への対応

--- a/services/monolith/kubernetes/overlays/develop/kustomization.yaml
+++ b/services/monolith/kubernetes/overlays/develop/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
 patches:
   - path: configmap.yaml
   - path: deployment.yaml
-# Test diff for deploy-kubernetes verification

--- a/services/monolith/kubernetes/overlays/develop/kustomization.yaml
+++ b/services/monolith/kubernetes/overlays/develop/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 patches:
   - path: configmap.yaml
   - path: deployment.yaml
+# Test diff for deploy-kubernetes verification

--- a/services/monolith/kubernetes/overlays/develop/kustomization.yaml
+++ b/services/monolith/kubernetes/overlays/develop/kustomization.yaml
@@ -6,6 +6,4 @@ resources:
 patches:
   - path: configmap.yaml
   - path: deployment.yaml
-labels:
-  - pairs:
-      ci.test/verification: "true"
+# Test diff for deploy-kubernetes verification

--- a/services/monolith/kubernetes/overlays/develop/kustomization.yaml
+++ b/services/monolith/kubernetes/overlays/develop/kustomization.yaml
@@ -6,4 +6,6 @@ resources:
 patches:
   - path: configmap.yaml
   - path: deployment.yaml
-# Test diff for deploy-kubernetes verification
+labels:
+  - pairs:
+      ci.test/verification: "true"


### PR DESCRIPTION
## Summary

- `auto-label--deploy-trigger` に kubernetes overlay の diff 表示を追加する設計ドキュメントを起票
- 既存 `deploy-terragrunt` / `deploy-container` と対称な `deploy-kubernetes` ジョブ + `reusable--kubernetes-executor.yaml` を設計
- PR ブランチ vs base ブランチの `kustomize build` 出力を `dyff between` で比較し、sticky comment で PR 上に表示

## Scope

- PR イベントのみ（`push to main` では発火しない）
- 1 コメント = 1 (service × environment)、sticky で上書き更新
- 実クラスタへの apply / kubectl diff は対象外
- 当面このリポジトリ内の reusable workflow に inline 実装（`panicboat/deploy-actions` への切り出しは将来）

## Test plan

- [ ] 設計レビュー完了後、writing-plans で実装計画へ進める
- [ ] 実装 PR にて実際の挙動検証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests now show per-service, per-environment Kubernetes manifest diffs as sticky PR comments, including collapsible detailed diffs when changes exist.
  * Diff checks run for PRs across all affected services/environments without blocking other checks (failures don’t stop remaining matrix entries).

* **Documentation**
  * Added design and plan docs describing the Kubernetes diff-on-deploy behavior, validation steps, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->