### PR TITLE
chore(.code-workspace): update worktrees path to .claude/worktrees

### DIFF
--- a/.code-workspace
+++ b/.code-workspace
@@ -1,13 +1,15 @@
 {
   "folders": [
-    { "path": "." }
+    {
+      "path": "."
+    }
   ],
   "settings": {
     "search.exclude": {
-      ".worktrees": true
+      ".claude/worktrees": true
     },
     "files.watcherExclude": {
-      "**/.worktrees/**": true
+      ".claude/worktrees/**": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- `.code-workspace` の worktrees パスを `.worktrees` から `.claude/worktrees` に更新

## Test plan

- [ ] VS Code で `.claude/worktrees` 配下のファイルが検索・ウォッチ対象から除外されることを確認