### PR TITLE
refactor: simplify claude-code-action caller workflow

### DIFF
--- a/.github/workflows/claude-code-action.yaml
+++ b/.github/workflows/claude-code-action.yaml
@@ -21,8 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: |
-      (contains(github.event.comment.body, '@claude') || contains(github.event.issue.body, '@claude')) &&
-      contains(fromJSON(vars.CLOUD_CODE_ALLOWED_USERS), github.actor)
+      contains(github.event.comment.body, '@claude') ||
+      contains(github.event.issue.body, '@claude') ||
+      contains(github.event.review.body, '@claude')
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -36,5 +37,4 @@ jobs:
         uses: panicboat/deploy-actions/claude-code-action@main
         with:
           token: ${{ steps.app-token.outputs.token }}
-          aws-role-arn: arn:aws:iam::559744160976:role/ai-assistant-develop-github-actions-role
           trigger-phrase: "@claude"


### PR DESCRIPTION
## Summary
- `if` 条件から `CLOUD_CODE_ALLOWED_USERS` 参照を削除（認可は `action.yaml` 側に移管）
- `aws-role-arn` を削除（`action.yaml` のデフォルト値を使用）
- `pull_request_review` イベント対応のため `review.body` チェックを追加