### PR TITLE
refactor(workflows): switch personal wrappers to panicboat-actions

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -21,7 +21,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Auto-approve PRs
-        uses: panicboat/deploy-actions/auto-approve@main
+        uses: panicboat/panicboat-actions/auto-approve@main
         with:
           token: ${{ steps.app-token.outputs.token }}
           auto-merge-label: 'automerge'

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -124,7 +124,7 @@ jobs:
   #       target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
   #     fail-fast: false
   #   steps:
-  #     - uses: panicboat/deploy-actions/container-cleaner@main
+  #     - uses: panicboat/panicboat-actions/container-cleaner@main
   #       if: matrix.target.stack == 'docker'
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-action.yaml
+++ b/.github/workflows/claude-code-action.yaml
@@ -34,6 +34,6 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Run Claude Code
-        uses: panicboat/deploy-actions/claude-code-action@main
+        uses: panicboat/panicboat-actions/claude-code-action@main
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/cleanup-container-image.yaml
+++ b/.github/workflows/cleanup-container-image.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Cleanup container images
-        uses: panicboat/deploy-actions/container-cleaner@main
+        uses: panicboat/panicboat-actions/container-cleaner@main
         with:
           # GitHub Container Registry requires PERSONAL_ACCESS_TOKEN, not Fine-grained personal access tokens
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable--container-builder.yaml
+++ b/.github/workflows/reusable--container-builder.yaml
@@ -38,7 +38,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Build and push container with custom tags
-        uses: panicboat/deploy-actions/container-builder@main
+        uses: panicboat/panicboat-actions/container-builder@main
         with:
           # Use GITHUB_TOKEN to ensure permission to create new packages
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -55,7 +55,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Kubernetes Diff
-        uses: panicboat/deploy-actions/kubernetes@main
+        uses: panicboat/panicboat-actions/kubernetes@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -59,7 +59,7 @@ jobs:
         continue-on-error: true
 
       - name: Execute Terragrunt
-        uses: panicboat/deploy-actions/terragrunt@main
+        uses: panicboat/panicboat-actions/terragrunt@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}


### PR DESCRIPTION
## Summary

terragrunt / kubernetes / claude-code-action / auto-approve / container-builder / container-cleaner の \`uses:\` を \`panicboat/panicboat-actions/...@main\` に切り替え。

## Test plan

- [ ] PR 上で全 workflow の CI が通ることを確認
- [ ] \`grep -rn panicboat/deploy-actions/ .github/workflows\` で label-dispatcher / label-resolver のみ残ることを確認