### PR TITLE
Switch panicboat-actions references to renamed actions

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -20,8 +20,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Auto-approve PRs
-        uses: panicboat/panicboat-actions/auto-approve@main
+      - name: Auto-approve
+        uses: hmarr/auto-approve-action@v4.0.0
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          auto-merge-label: 'automerge'
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -124,11 +124,14 @@ jobs:
   #       target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
   #     fail-fast: false
   #   steps:
-  #     - uses: panicboat/panicboat-actions/container-cleaner@main
+  #     - name: Cleanup container
+  #       uses: dataaxiom/ghcr-cleanup-action@v1.0.16
   #       if: matrix.target.stack == 'docker'
   #       with:
   #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         image-name: monorepo/${{ matrix.target.service }}
+  #         package: monorepo/${{ matrix.target.service }}
+  #         keep-n-untagged: 0
+  #         use-regex: true
   #   continue-on-error: true
 
   deployment-summary:

--- a/.github/workflows/claude-code-action.yaml
+++ b/.github/workflows/claude-code-action.yaml
@@ -34,6 +34,6 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Run Claude Code
-        uses: panicboat/panicboat-actions/claude-code-action@main
+        uses: panicboat/panicboat-actions/claude-run@main
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/cleanup-container-image.yaml
+++ b/.github/workflows/cleanup-container-image.yaml
@@ -19,13 +19,42 @@ jobs:
         service: ["handbooks", "monolith", "nyx"]
       fail-fast: false
     steps:
-      - name: Cleanup container images
-        uses: panicboat/panicboat-actions/container-cleaner@main
+      # Step 1: Clean old PR tags (pr-*, older than retention days)
+      - name: Clean old PR tags
+        uses: dataaxiom/ghcr-cleanup-action@v1.0.16
         with:
-          # GitHub Container Registry requires PERSONAL_ACCESS_TOKEN, not Fine-grained personal access tokens
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ${{ matrix.service }}
-          pr-retention-days: 1
+          package: ${{ github.event.repository.name }}/${{ matrix.service }}
+          delete-tags: ^pr-
+          older-than: 1 days
+          exclude-tags: ^(latest|v\d+\.\d+\.\d+.*)$
+          use-regex: true
+          validate: true
+
+      # Step 2: Clean all SHA tags (sha-*, regardless of age)
+      - name: Clean SHA tags
+        uses: dataaxiom/ghcr-cleanup-action@v1.0.16
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package: ${{ github.event.repository.name }}/${{ matrix.service }}
+          delete-tags: ^sha-
+          exclude-tags: ^(latest|v\d+\.\d+\.\d+.*)$
+          use-regex: true
+          validate: true
+
+      # Step 3: Clean all untagged images and orphaned images
+      - name: Clean untagged images
+        uses: dataaxiom/ghcr-cleanup-action@v1.0.16
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package: ${{ github.event.repository.name }}/${{ matrix.service }}
+          keep-n-untagged: 0
+          delete-orphaned-images: true
+          delete-ghost-images: true
+          delete-partial-images: true
+          exclude-tags: ^(latest|v\d+\.\d+\.\d+.*)$
+          use-regex: true
+          validate: true
 
   summary:
     name: 'Cleanup Summary'

--- a/.github/workflows/reusable--container-builder.yaml
+++ b/.github/workflows/reusable--container-builder.yaml
@@ -37,13 +37,41 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
-      - name: Build and push container with custom tags
-        uses: panicboat/panicboat-actions/container-builder@main
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
         with:
           # Use GITHUB_TOKEN to ensure permission to create new packages
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-name: ${{ inputs.image-name }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ inputs.image-name }}
+          tags: |
+            type=sha
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.actor }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7.1.0
+        with:
           platforms: linux/arm64
-          working-directory: ${{ inputs.working-directory }}
-          tags-template: |
-            type=raw,value=${{ github.actor}}
+          context: ${{ inputs.working-directory }}
+          file: ${{ inputs.working-directory }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -54,10 +54,10 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Kubernetes Diff
-        uses: panicboat/panicboat-actions/kubernetes@main
+      - name: Kustomize Diff
+        uses: panicboat/panicboat-actions/kustomize-diff@main
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           path: ${{ inputs.path }}

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -59,14 +59,13 @@ jobs:
         continue-on-error: true
 
       - name: Execute Terragrunt
-        uses: panicboat/panicboat-actions/terragrunt@main
+        uses: panicboat/panicboat-actions/terragrunt-run@main
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           action-type: ${{ inputs.action-type }}
           iam-role: ${{ inputs.iam-role }}
           aws-region: ${{ inputs.aws-region }}
           working-directory: ${{ inputs.working-directory }}
-          repository: ${{ github.repository }}
           pr-number: ${{ steps.pr-info.outputs.number }}


### PR DESCRIPTION
## Summary
- `auto-approve.yaml`: call `hmarr/auto-approve-action@v4.0.0` directly, drop auto-merge.
- `claude-code-action.yaml`: switch reference to `panicboat-actions/claude-run@main`.
- `reusable--kubernetes-builder.yaml`: switch to `kustomize-diff@main`, rename `github-token` → `token`.
- `reusable--terragrunt-executor.yaml`: switch to `terragrunt-run@main`, rename `github-token` → `token`, drop `repository`.
- `reusable--container-builder.yaml`: inline build steps (no longer use `container-builder@main`).
- `cleanup-container-image.yaml`: inline cleanup steps (no longer use `container-cleaner@main`).
- `auto-label--deploy-trigger.yaml`: refresh the commented-out cleanup snippet.

Depends on: panicboat-actions PR (Phase 1) merged ✓.

## Test plan
- [ ] Trigger a bot PR to verify `auto-approve.yaml` (approve only, no merge)
- [ ] Comment `@claude` on a PR/issue to verify `claude-code-action.yaml`
- [ ] Open a PR touching kubernetes overlays to verify `reusable--kubernetes-builder.yaml`
- [ ] Open a PR touching terragrunt configs to verify `reusable--terragrunt-executor.yaml`
- [ ] Open a PR touching a Dockerfile to verify `reusable--container-builder.yaml`
- [ ] Manually dispatch `cleanup-container-image.yaml` to verify cleanup steps