### PR TITLE
chore: migrate workflow-config to stack-grouped schema

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -1,26 +1,38 @@
 environments:
   - environment: develop
-    aws_region: ap-northeast-1
-    iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
-    iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+    stacks:
+      terragrunt:
+        aws_region: ap-northeast-1
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+      kubernetes: {}
+      docker: {}
 
   # - environment: staging
-  #   aws_region: ap-northeast-1
-  #   iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-staging-role
-  #   iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-staging-role
+  #   stacks:
+  #     terragrunt:
+  #       aws_region: ap-northeast-1
+  #       iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-staging-role
+  #       iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-staging-role
+  #     kubernetes: {}
+  #     docker: {}
 
   # - environment: production
-  #   aws_region: ap-northeast-1
-  #   iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-production-role
-  #   iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-production-role
+  #   stacks:
+  #     terragrunt:
+  #       aws_region: ap-northeast-1
+  #       iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-production-role
+  #       iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-production-role
+  #     kubernetes: {}
+  #     docker: {}
 
-directory_conventions:
+stack_conventions:
   - root: services/{service}
     stacks:
       - name: docker
         directory: workspace
       - name: terragrunt
         directory: terragrunt/envs/{environment}
+        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
       - name: kubernetes
         directory: kubernetes/overlays/{environment}
-


### PR DESCRIPTION
## Summary

- `environments[]` 直下のフラット属性 (`aws_region` / `iam_role_*`) を `environments[].stacks.<name>.<attr>` の stack-grouped 構造に移行。
- `directory_conventions` セクションを `stack_conventions` にリネームし、`terragrunt` stack に `required_attributes: [aws_region, iam_role_plan, iam_role_apply]` を宣言。
- `kubernetes` / `docker` stack は AWS attribute を要求しないため、environment 配下では `{}` 表記。
- staging / production のコメントアウトされた envinronment ブロックも新スキーマに合わせて書き換え（コメント維持）。

## Context

`panicboat/deploy-actions` の `feat/stack-grouped-attributes` (PR #202) で action-scripts 側のスキーマ移行が完了したため、本 PR で利用側の `workflow-config.yaml` を追従。`auto-label--deploy-trigger.yaml` 等が参照する matrix item のキー名は維持されるため、workflow ファイル自体への変更は不要。

## Test plan

- [ ] `config-manager validate` で新 YAML が valid と判定される（手元で確認済み）
- [ ] `auto-label--label-dispatcher` / `auto-label--deploy-trigger` の動作確認（PR レビュー時に GitHub Actions 上で確認）