### PR TITLE
fix(monolith): enforce frozen bundle install in Dockerfile

### DIFF
--- a/services/monolith/workspace/Dockerfile
+++ b/services/monolith/workspace/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Install gems
 COPY Gemfile Gemfile.lock ./
-RUN bundle install
+RUN bundle config set --local frozen true && bundle install
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## Summary

- monolith の Dockerfile で `bundle install` に `--local frozen true` を強制し、Gemfile.lock と installed gem の不整合を防ぐ

## Background

`ghcr.io/panicboat/monorepo/monolith:latest` (2026-04-23 build, `sha256:2863bf2c...`) を pull して中身を確認したところ:

| 内容 | 値 |
|---|---|
| image 内 `/app/Gemfile.lock` の gruf | `gruf (2.21.1)` |
| image 内 installed gem | `gruf-2.22.0` |

ソース commit (`af83e38f`) の Gemfile.lock も `gruf (2.21.1)` であり、にも関わらず `bundle install` が `gruf-2.22.0` を解決していた。pod 起動時に bundler が `Could not find gruf-2.21.1 in locally installed gems (Bundler::GemNotFound)` で起動失敗。

`bundle config set --local frozen true` を追加することで、lockfile から逸脱した解決を許可しなくする。次回 main への push で image が再ビルドされ、修復される想定。

## Test plan

- [ ] PR マージ後の image 再ビルドを待ち、ローカル k3d で `monolith` pod が `Running` になることを確認
- [ ] 万一 frozen で build が失敗する場合、Gemfile/Gemfile.lock の真のドリフト原因を別途調査する