### PR TITLE
fix: align with platform OIDC hardening

### DIFF
--- a/.github/workflows/ci-gatekeeper.yaml
+++ b/.github/workflows/ci-gatekeeper.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  actions: read
+
 jobs:
   ci-gatekeeper:
     name: CI Gatekeeper

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -3,8 +3,8 @@ environments:
     stacks:
       terragrunt:
         aws_region: ap-northeast-1
-        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
-        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-role
+        iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-plan-role
+        iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
       kubernetes: {}
       docker: {}
 


### PR DESCRIPTION
## Summary

Catches up `monorepo` with the OIDC hardening that landed in `panicboat/platform` (PRs #230, #231, #232). Two files in this repo were not updated as part of the platform PRs and are currently broken / about to break:

- `workflow-config.yaml`: `iam_role_plan` / `iam_role_apply` still pointed at `github-oidc-auth-develop-github-actions-role`, which was deleted in `panicboat/platform` PR #231. Any terragrunt-stacked PR or main push would fail with role-not-found. Switched to the new `...-plan-role` / `...-apply-role` ARNs.
- `.github/workflows/ci-gatekeeper.yaml`: had no top-level `permissions:` block. After `panicboat/platform` PR #232 set `monorepo`'s default workflow permissions to `read`, the implicit `GITHUB_TOKEN` lost `actions: read`, breaking `int128/wait-for-workflows-action`. Added an explicit `permissions: actions: read` block.

## Diff

```
workflow-config.yaml             | 4 ++--
.github/workflows/ci-gatekeeper.yaml | 3 +++
2 files changed, 5 insertions(+), 2 deletions(-)
```

Other monorepo workflows (`auto-approve`, `auto-label--deploy-trigger`, `auto-label--label-dispatcher`, `claude-code-action`, `cleanup-container-image`) already declare explicit top-level `permissions:` blocks and are unaffected.

## Test plan

- [ ] PR plan job for any terragrunt-stacked path runs with the new plan-role ARN and succeeds
- [ ] After merge, apply job runs with the new apply-role ARN and succeeds
- [ ] `ci-gatekeeper.yaml` completes on this PR (it now has explicit `actions: read`)
- [ ] Other workflows on this PR continue to behave as before

## Related

- panicboat/platform#230 — Phase 1+2: new plan-role / apply-role + workflow-config switch
- panicboat/platform#231 — Phase 3: legacy role deletion
- panicboat/platform#232 — Phase 4+5: ci-gatekeeper permissions + default workflow permissions = read
- Spec: panicboat/platform `docs/superpowers/specs/2026-04-30-oidc-hardening-design.md`