### PR TITLE
fix(ci): run lint-actions on every PR (Required check needs to register)

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '**/action.yml'
-      - '**/action.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Drop the `pull_request: paths:` filter on `lint-actions.yml`. Since `Ensure actions are pinned to SHAs` is now a Required check (added via Phase 4 of the SHA pinning rollout), the workflow must run on every PR — otherwise the check is never registered and the PR is permanently blocked.

The job is ~5 seconds, so the per-PR overhead is negligible.

## Background
Discovered when Renovate PRs (e.g. this repo's #574, `panicboat/platform#249`) ended up `BLOCKED` because their file changes didn't match the previous `paths:` filter.

## Test plan
- [ ] `Ensure actions are pinned to SHAs` check appears and passes on this PR