### PR TITLE
chore(.github): enable Renovate lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,11 @@
   ],
   "minimumReleaseAge": "1 day",
   "separateMinorPatch": false,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am every weekday"],
+    "automerge": true
+  },
   "packageRules": [
     {
       "description": "Default: separate PRs per package",


### PR DESCRIPTION
## Summary

- Renovate に `lockFileMaintenance` を有効化し、各種 lock ファイル (Gemfile.lock, package-lock.json, go.sum 等) を別 PR で定期更新させる
- `rangeStrategy: bump` で constraint だけが更新され lock が取り残されると CI が失敗する事象を、別 PR の lock 更新で防止する
- スケジュール・automerge は既存ポリシーに合わせて weekday 4am / automerge 有効。production への automerge は既存ルールでブロック継続

[panicboat/platform#253](https://github.com/panicboat/platform/pull/253) と同等の変更を monorepo にも適用するもの。

## Test plan

- [ ] PR の Renovate config validator が pass する
- [ ] merge 後、次回 Renovate 実行で `lockFileMaintenance` PR が生成されることを確認
- [ ] 生成された PR の CI が pass することを確認