### PR TITLE
chore(.github): revert Renovate lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,11 +27,6 @@
   ],
   "minimumReleaseAge": "1 day",
   "separateMinorPatch": false,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 4am every weekday"],
-    "automerge": true
-  },
   "packageRules": [
     {
       "description": "Default: separate PRs per package",


### PR DESCRIPTION
## Summary

[#580](https://github.com/panicboat/monorepo/pull/580) で入れた `lockFileMaintenance` を revert する。

## Why

- 本リポジトリでは `.terraform.lock.hcl` は元から `.gitignore` 対象で、`lockFileMaintenance` の主要動機（terraform lock の同期問題）は該当しなかった
- 他 lock ファイル (Gemfile.lock, package-lock.json, go.sum 等) の週次メンテ PR は、現状の運用規模では恩恵に対し PR ノイズが多い
- [panicboat/platform#254](https://github.com/panicboat/platform/pull/254) で platform 側も「lock を追跡しない」方針に切り替えるため、両 repo で揃える

## Test plan

- [ ] PR の Renovate config validator が pass する
- [ ] merge 後、次の Renovate 実行サイクルで `lockFileMaintenance` 由来の PR が生成されないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified dependency management configuration by removing automated lock file maintenance settings and associated scheduling preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->