### PR TITLE
fix(ci): drive deploy-trigger from pull_request:closed instead of push:main

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -2,12 +2,9 @@ name: 'Auto Label - Deploy Trigger'
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, closed]
     branches:
       - '**'
-  push:
-    branches:
-      - main
 
 permissions:
   id-token: write
@@ -16,12 +13,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-trigger-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: deploy-trigger-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: ${{ github.event.action == 'labeled' }}
 
 jobs:
   deploy-trigger:
     name: 'Deployment Trigger'
+    if: github.event.action == 'labeled' || (github.event.action == 'closed' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.resolver.outputs.targets }}
@@ -35,20 +33,12 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - name: Get PR information
-        id: pr-info
-        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          state: all
-        continue-on-error: true
-
       - name: Label Resolver
         id: resolver
         uses: panicboat/deploy-actions/label-resolver@3399490d98d6e4d4ff1a06badfd63d9f9a0c8699 # v1.1.0
         with:
           repository: ${{ github.repository }}
-          pr-number: ${{ steps.pr-info.outputs.number }}
+          pr-number: ${{ github.event.pull_request.number }}
           github-token: ${{ steps.app-token.outputs.token }}
           config-path: 'workflow-config.yaml'
 
@@ -66,8 +56,8 @@ jobs:
     with:
       service-name: ${{ matrix.target.service }}
       environment: ${{ matrix.target.environment }}
-      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event_name == 'pull_request' && 'plan' || 'apply') || '' }}
-      iam-role: ${{ github.event_name == 'pull_request' && matrix.target.iam_role_plan || matrix.target.iam_role_apply }}
+      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event.pull_request.merged && 'apply' || 'plan') || '' }}
+      iam-role: ${{ github.event.pull_request.merged && matrix.target.iam_role_apply || matrix.target.iam_role_plan }}
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
@@ -96,7 +86,7 @@ jobs:
     name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
     needs: deploy-trigger
     if: |
-      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
     strategy:

--- a/.github/workflows/reusable--container-builder.yaml
+++ b/.github/workflows/reusable--container-builder.yaml
@@ -61,7 +61,7 @@ jobs:
           tags: |
             type=sha
             type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event.pull_request.merged == true }}
             type=raw,value=${{ github.actor }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Why

`Auto Label - Deploy Trigger` の post-merge run で deploy 系 job が断続的に skip される race condition を修正します。platform 側の同症状を [panicboat/platform#322](https://github.com/panicboat/platform/pull/322) で対処しているのと同じパターンです。

### Root cause

`jwalton/gh-find-current-pr@v1.3.5` は `push: main` event で PR を解決するために `GET /repos/{owner}/{repo}/commits/{sha}/pulls` を呼びます。GitHub は squash merge 直後の commit↔PR association を**非同期で書き込む**ため、この endpoint は数秒〜数十秒の間 **空配列を返すことがあります**。post-merge workflow がその window で発火すると、`pr-number` が空 → label resolver が `targets: []` → 全 deploy job が skip。

### 直近の発生事例

- #589 update panicboat/deploy-actions action to v1.1.0

## What

`push: main` を廃し、`pull_request: types: [labeled, closed]` 1 本にまとめます。`closed` event payload は `pull_request.number` / `.labels` / `.merged` を merge 同期で持つため、API lookup 不要 → race 消滅。

### Diff のポイント

#### `auto-label--deploy-trigger.yaml`
- \`on:\` から \`push: main\` を削除、\`pull_request.types\` に \`closed\` を追加
- \`deploy-trigger\` job に \`if: action == 'labeled' || (action == 'closed' && merged == true)\` を追加
- \`Get PR information\` step を削除し、\`pr-number\` を \`github.event.pull_request.number\` 直参照に
- terragrunt の \`action-type\` / \`iam-role\` を \`event_name\` 比較から \`merged\` フラグに切替
- \`concurrency\` を \`(pr-number, action)\` ベースに、\`cancel-in-progress\` は \`labeled\` 時のみ
- \`deploy-kubernetes\` の gate を \`event_name == 'pull_request'\` → \`event.action == 'labeled'\`（kubernetes は元々 PR-time のみで動く設計、それを維持）

#### `reusable--container-builder.yaml`
- Docker メタデータの \`latest\` タグ条件：
  - \`type=raw,value=latest,enable={{is_default_branch}}\`
  - → \`type=raw,value=latest,enable=\${{ github.event.pull_request.merged == true }}\`
- 理由：\`{{is_default_branch}}\` は \`push: refs/heads/main\` 時のみ true。\`pull_request: closed\` だと \`github.ref = refs/pull/N/merge\` で false になり \`latest\` が付かなくなる

## Side effects

- **main への直接 push では apply / container build されなくなります**（PR 経由のみ）。main は protected で直 push 不可の前提なので実害なしと判断
- 移行は段階的：\`pull_request\` event は **PR head SHA の workflow file** で動くため、本 PR マージ前に open 済みの PR は merge 時も旧 \`push: main\` path を使います。新規 PR から自動で新 path

## Out of scope

- \`reusable--terragrunt-executor.yaml\` 内部の \`gh-find-current-pr\` race：apply 結果コメントの post に影響するだけで apply 実行自体は止まらないため、別 PR で対応
- \`reusable--kubernetes-builder.yaml\` 内部の \`gh-find-current-pr\` race：本 PR 後 kubernetes は \`labeled\` 時のみ呼ばれる（= PR open 中）ため、\`commits/{sha}/pulls\` は確実にヒットし race は実害なし

## Test plan

マージ後、最初に merge される deploy 系 PR が新 path で apply / container build 走ること、および \`latest\` タグが ghcr に push されることを確認。

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment automation workflow to respond to pull request label and close events instead of manual push configurations, with enhanced concurrency scoping, selective job execution, and improved deployment logic.
  * Enhanced container image builder workflow's "latest" tag enablement to use refined conditions for accurate release versioning during pull request merges and releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/591)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->