### PR TITLE
refactor(ci): pass pr-number from caller to deploy reusables

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -61,6 +61,7 @@ jobs:
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
+      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -99,6 +100,7 @@ jobs:
       environment: ${{ matrix.target.environment }}
       path: ${{ matrix.target.stack == 'kubernetes' && matrix.target.working_directory || '' }}
       app-id: ${{ vars.APP_ID }}
+      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
+      pr-number:
+        required: true
+        type: string
+        description: 'Pull request number for posting kustomize diff comment'
     secrets:
       private-key:
         required: true
@@ -41,14 +45,6 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
-      - name: Get PR information
-        id: pr-info
-        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          state: all
-        continue-on-error: true
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -61,4 +57,4 @@ jobs:
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           path: ${{ inputs.path }}
-          pr-number: ${{ steps.pr-info.outputs.number }}
+          pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -31,6 +31,10 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
+      pr-number:
+        required: true
+        type: string
+        description: 'Pull request number for posting plan/apply result comment'
     secrets:
       private-key:
         required: true
@@ -50,14 +54,6 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
-      - name: Get PR information
-        id: pr-info
-        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          state: all
-        continue-on-error: true
-
       - name: Execute Terragrunt
         uses: panicboat/panicboat-actions/terragrunt-run@f917fa0921e06ec7b08941df04958361c43253fb # main
         with:
@@ -68,4 +64,4 @@ jobs:
           iam-role: ${{ inputs.iam-role }}
           aws-region: ${{ inputs.aws-region }}
           working-directory: ${{ inputs.working-directory }}
-          pr-number: ${{ steps.pr-info.outputs.number }}
+          pr-number: ${{ inputs.pr-number }}


### PR DESCRIPTION
## Why

[#591](https://github.com/panicboat/monorepo/pull/591) で caller (\`auto-label--deploy-trigger.yaml\`) を \`pull_request\` event 1 本に統一し、PR 番号は payload (\`github.event.pull_request.number\`) から直接取れるようになりました。一方で 2 つの reusable workflow は依然として **internal で \`jwalton/gh-find-current-pr\` を呼んで PR を再検索**しています。重複した API call と不要な third-party 依存を削減する cleanup です。

これは **bug fix ではなく structural cleanup**：#591 後はどの reusable も \`pull_request\` event 配下から呼ばれ、\`gh-find-current-pr\` の default sha が \`pull_request.head.sha\` を選びます。head SHA ↔ PR association は PR 作成時点で安定しているので race は発生しません。今回の race は \`merge_commit_sha\` に対する propagation 遅延限定で、#591 でその経路はすでに消えています。

panicboat/platform 側の同等 cleanup は [panicboat/platform#325](https://github.com/panicboat/platform/pull/325) で並行対応中です。

## What

2 つの reusable を「caller が PR context を所有 → input として渡す」形に揃える：

### Reusable 側（2 ファイル）
- \`pr-number\` を \`workflow_call.inputs\` に追加（required）
- \`Get PR information\` step を削除
- \`steps.pr-info.outputs.number\` → \`inputs.pr-number\` に置換

対象：
- \`reusable--terragrunt-executor.yaml\`
- \`reusable--kubernetes-builder.yaml\`

### Caller 側（1 ファイル）
- 2 つの reusable invocation に \`pr-number: \${{ github.event.pull_request.number }}\` を追加

## Out of scope

- \`auto-label--label-dispatcher.yaml\` 内の \`gh-find-current-pr\`：別 workflow / 別スコープのため本 PR では touch しない
- \`reusable--container-builder.yaml\`：そもそも \`gh-find-current-pr\` を使っていないため変更不要

## Test plan

マージ後、最初の deploy 系 PR で：
- terragrunt plan/apply 結果コメントが PR に post される
- kustomize-diff コメントが PR に post される

を確認。

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)