### PR TITLE
revert(ci): restore push:main deploy-trigger (revert #591 + #592)

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -2,9 +2,12 @@ name: 'Auto Label - Deploy Trigger'
 
 on:
   pull_request:
-    types: [labeled, closed]
+    types: [labeled]
     branches:
       - '**'
+  push:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -13,13 +16,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-trigger-${{ github.event.pull_request.number }}-${{ github.event.action }}
-  cancel-in-progress: ${{ github.event.action == 'labeled' }}
+  group: deploy-trigger-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy-trigger:
     name: 'Deployment Trigger'
-    if: github.event.action == 'labeled' || (github.event.action == 'closed' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.resolver.outputs.targets }}
@@ -33,12 +35,20 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
+
       - name: Label Resolver
         id: resolver
         uses: panicboat/deploy-actions/label-resolver@3399490d98d6e4d4ff1a06badfd63d9f9a0c8699 # v1.1.0
         with:
           repository: ${{ github.repository }}
-          pr-number: ${{ github.event.pull_request.number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
           github-token: ${{ steps.app-token.outputs.token }}
           config-path: 'workflow-config.yaml'
 
@@ -56,8 +66,8 @@ jobs:
     with:
       service-name: ${{ matrix.target.service }}
       environment: ${{ matrix.target.environment }}
-      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event.pull_request.merged && 'apply' || 'plan') || '' }}
-      iam-role: ${{ github.event.pull_request.merged && matrix.target.iam_role_apply || matrix.target.iam_role_plan }}
+      action-type: ${{ matrix.target.stack == 'terragrunt' && (github.event_name == 'pull_request' && 'plan' || 'apply') || '' }}
+      iam-role: ${{ github.event_name == 'pull_request' && matrix.target.iam_role_plan || matrix.target.iam_role_apply }}
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
@@ -86,7 +96,7 @@ jobs:
     name: 'Deploy Kubernetes (${{ matrix.target.service }}:${{ matrix.target.environment }})'
     needs: deploy-trigger
     if: |
-      github.event.action == 'labeled' &&
+      github.event_name == 'pull_request' &&
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"kubernetes"')
     strategy:

--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -61,7 +61,6 @@ jobs:
       aws-region: ${{ matrix.target.aws_region }}
       working-directory: ${{ matrix.target.working_directory }}
       app-id: ${{ vars.APP_ID }}
-      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -100,7 +99,6 @@ jobs:
       environment: ${{ matrix.target.environment }}
       path: ${{ matrix.target.stack == 'kubernetes' && matrix.target.working_directory || '' }}
       app-id: ${{ vars.APP_ID }}
-      pr-number: ${{ github.event.pull_request.number }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
 

--- a/.github/workflows/reusable--container-builder.yaml
+++ b/.github/workflows/reusable--container-builder.yaml
@@ -61,7 +61,7 @@ jobs:
           tags: |
             type=sha
             type=ref,event=pr
-            type=raw,value=latest,enable=${{ github.event.pull_request.merged == true }}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ github.actor }}
 
       - name: Build and push Docker image

--- a/.github/workflows/reusable--kubernetes-builder.yaml
+++ b/.github/workflows/reusable--kubernetes-builder.yaml
@@ -19,10 +19,6 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
-      pr-number:
-        required: true
-        type: string
-        description: 'Pull request number for posting kustomize diff comment'
     secrets:
       private-key:
         required: true
@@ -45,6 +41,14 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -57,4 +61,4 @@ jobs:
           service-name: ${{ inputs.service-name }}
           environment: ${{ inputs.environment }}
           path: ${{ inputs.path }}
-          pr-number: ${{ inputs.pr-number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}

--- a/.github/workflows/reusable--terragrunt-executor.yaml
+++ b/.github/workflows/reusable--terragrunt-executor.yaml
@@ -31,10 +31,6 @@ on:
         required: true
         type: string
         description: 'GitHub App ID for authentication'
-      pr-number:
-        required: true
-        type: string
-        description: 'Pull request number for posting plan/apply result comment'
     secrets:
       private-key:
         required: true
@@ -54,6 +50,14 @@ jobs:
           private-key: ${{ secrets.private-key }}
           owner: ${{ github.repository_owner }}
 
+      - name: Get PR information
+        id: pr-info
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          state: all
+        continue-on-error: true
+
       - name: Execute Terragrunt
         uses: panicboat/panicboat-actions/terragrunt-run@f917fa0921e06ec7b08941df04958361c43253fb # main
         with:
@@ -64,4 +68,4 @@ jobs:
           iam-role: ${{ inputs.iam-role }}
           aws-region: ${{ inputs.aws-region }}
           working-directory: ${{ inputs.working-directory }}
-          pr-number: ${{ inputs.pr-number }}
+          pr-number: ${{ steps.pr-info.outputs.number }}


### PR DESCRIPTION
## Why

PR #591 で deploy-trigger を `push:main` から `pull_request:closed` に変更した結果、apply 時の OIDC `sub` claim が `repo:panicboat/monorepo:ref:refs/heads/main` から `repo:panicboat/monorepo:pull_request` に変わり、`platform/aws/github-oidc-auth` の apply role trust policy にマッチしなくなった。

`apply_conditions` は `refs/heads/main` か `environment:<env>` のみ許可しているため、PR merge 時の `pull_request:closed` イベントからは AssumeRoleWithWebIdentity が拒否される。

(platform 側で同じ事象が発生: https://github.com/panicboat/platform/actions/runs/25629374777/job/75230187362)

## What

- Revert #592 (`refactor(ci): pass pr-number from caller to deploy reusables`) — #591 と一体の修正のため
- Revert #591 (`fix(ci): drive deploy-trigger from pull_request:closed instead of push:main`)

トリガーが `push:main` + `pull_request:[labeled]` に戻り、apply 時の OIDC sub も `refs/heads/main` に戻る。

なお #593 (revert PR) は CLOSED されていたため、本 PR で作り直し。

## Followup

`pull_request:closed` 駆動 + 多層防御 (GitHub Environment + deployment branch policy + `job_workflow_ref` claim) で再設計するなら別 PR で。