### PR TITLE
fix(flux): ImagePolicy interval (= controller validation)

### DIFF
--- a/clusters/develop/services/frontend/image-policy.yaml
+++ b/clusters/develop/services/frontend/image-policy.yaml
@@ -9,6 +9,7 @@ spec:
   imageRepositoryRef:
     name: frontend
   digestReflectionPolicy: Always
+  interval: 10m
   filterTags:
     pattern: '^latest$'
   policy:

--- a/clusters/develop/services/monolith/image-policy.yaml
+++ b/clusters/develop/services/monolith/image-policy.yaml
@@ -17,6 +17,7 @@ spec:
   imageRepositoryRef:
     name: monolith
   digestReflectionPolicy: Always
+  interval: 10m
   filterTags:
     pattern: '^latest$'
   policy:


### PR DESCRIPTION
## Issue

image-reflector-controller v1.1.x が `spec.interval` を required validate (CEL rule):

```
ImagePolicy.image.toolkit.fluxcd.io "monolith" is invalid:
spec: Invalid value: spec.interval must be set when
spec.digestReflectionPolicy is set to 'Always'
```

monorepo-cluster Kustomization 全体が dry-run reject、 application stack (= monolith / frontend / reverse-proxy + RDS + ExternalSecret + ImageUpdateAutomation) deploy 不可。

## Fix

`clusters/develop/services/{monolith,frontend}/image-policy.yaml` の `spec` block に `interval: 10m` 追加 (= Flux standard polling cadence)。

## Validation

`kustomize build clusters/develop/services/{monolith,frontend}` で両 ImagePolicy resource の spec に `interval: 10m` 含むことを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated image update check intervals to 10 minutes for frontend and monolith services in the development environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->