### PR TITLE
fix(flux): ImageUpdateAutomation .Updated -> .Changed migration

### DIFF
--- a/clusters/develop/services/frontend/image-automation.yaml
+++ b/clusters/develop/services/frontend/image-automation.yaml
@@ -17,7 +17,7 @@ spec:
         email: panicboat@gmail.com
         name: panicboat
       messageTemplate: |
-        chore(frontend): bump image to {{range .Updated.Images}}{{println .}}{{end}}
+        chore(frontend): bump image to {{range .Changed.Changes}}{{ println .NewValue }}{{end}}
     push:
       branch: main
   update:

--- a/clusters/develop/services/monolith/image-automation.yaml
+++ b/clusters/develop/services/monolith/image-automation.yaml
@@ -17,7 +17,7 @@ spec:
         email: panicboat@gmail.com
         name: panicboat
       messageTemplate: |
-        chore(monolith): bump image to {{range .Updated.Images}}{{println .}}{{end}}
+        chore(monolith): bump image to {{range .Changed.Changes}}{{ println .NewValue }}{{end}}
     push:
       branch: main
   update:


### PR DESCRIPTION
## Issue

Flux image-automation-controller v1.1.x で commitTemplate 内 `.Updated` field が deprecated / removed。 monorepo の monolith / frontend ImageUpdateAutomation 両方が **Ready=False** with deprecation warning、 image auto-bump chain (= main merge → image push → digest detect → deployment.yaml commit) 停止状態。

## Fix

両 ImageUpdateAutomation の commitTemplate を新 syntax (`.Changed.Changes` + `.NewValue`) に migrate。

Reference: [Flux ImageUpdateAutomation commit message template](https://fluxcd.io/flux/components/image/imageupdateautomations/#commit-message-template)

### Diff (= 概要)

```diff
-      messageTemplate: |
-        chore(monolith): bump image to {{range .Updated.Images}}{{println .}}{{end}}
+      messageTemplate: |
+        chore(monolith): bump image to {{range .Changed.Changes}}{{ println .NewValue }}{{end}}
```

frontend も同 pattern。

## Validation

`kustomize build clusters/develop/services/{monolith,frontend}` で両 ImageUpdateAutomation messageTemplate に新 syntax 反映確認。 PR merge 後 Flux Reconcile で両 ImageUpdateAutomation Ready=True に復活想定。