### PR TITLE
chore: remove redundant empty stack declarations from workflow-config

### DIFF
--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -5,26 +5,6 @@ environments:
         aws_region: ap-northeast-1
         iam_role_plan: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-plan-role
         iam_role_apply: arn:aws:iam::559744160976:role/github-oidc-auth-develop-github-actions-apply-role
-      kubernetes: {}
-      docker: {}
-
-  # - environment: staging
-  #   stacks:
-  #     terragrunt:
-  #       aws_region: ap-northeast-1
-  #       iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-staging-role
-  #       iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-staging-role
-  #     kubernetes: {}
-  #     docker: {}
-
-  # - environment: production
-  #   stacks:
-  #     terragrunt:
-  #       aws_region: ap-northeast-1
-  #       iam_role_plan: arn:aws:iam::123456789012:role/terragrunt-plan-production-role
-  #       iam_role_apply: arn:aws:iam::123456789012:role/terragrunt-apply-production-role
-  #     kubernetes: {}
-  #     docker: {}
 
 stack_conventions:
   - root: services/{service}


### PR DESCRIPTION
## What

Remove `kubernetes: {}` and `docker: {}` from `environments[].stacks` in `workflow-config.yaml`. Also remove the commented-out staging / production blocks that only existed as templated examples.

## Why

These empty declarations are equivalent to omitting the key entirely:

- `WorkflowConfig#stack_attributes_for` (in deploy-actions) returns `{}` whether the stack key exists with an empty hash or is absent.
- `validate_config.rb` enforces `required_attributes` only on stacks that declare them; `kubernetes` / `docker` declare none, so the empty hash is a no-op.
- Matrix generation iterates `stack_conventions`, not `environments[].stacks`, and gates targets on directory existence.

Keeping them around added visual noise without conveying anything not already implied by `stack_conventions`.

## Verification

- YAML parses cleanly.
- Logical equivalent of `validate_config.rb` passes (terragrunt `required_attributes` are still declared on the develop env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up workflow configuration by removing inactive environment configurations, streamlining the setup for active development workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/605)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->