### PR TITLE
fix(monolith): add OTel exporter / propagator env vars (= Phase 6-3 fix forward)

### DIFF
--- a/services/monolith/kubernetes/base/deployment.yaml
+++ b/services/monolith/kubernetes/base/deployment.yaml
@@ -32,6 +32,16 @@ spec:
               value: http://opentelemetry-collector.monitoring.svc.cluster.local:4317
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: service.name=monolith
+            # exporter / propagator を明示しないと OTel SDK Ruby default = noop で span 消失。
+            # OTel Operator inject-ruby が auto 設定するはずの env vars を hardcode で 補完。
+            - name: OTEL_TRACES_EXPORTER
+              value: otlp
+            - name: OTEL_METRICS_EXPORTER
+              value: otlp
+            - name: OTEL_LOGS_EXPORTER
+              value: otlp
+            - name: OTEL_PROPAGATORS
+              value: tracecontext,baggage
           envFrom:
             - configMapRef:
                 name: monolith


### PR DESCRIPTION
## Summary

Phase 6-3 cluster validate で検出した monolith OTel data 0 件流入の fix forward。

## Root cause

- monolith Pod env vars が `OTEL_EXPORTER_OTLP_ENDPOINT` + `OTEL_RESOURCE_ATTRIBUTES` の 2 個のみ
- OTel SDK Ruby (= `config/initializers/opentelemetry.rb` の `c.use_all`) が全 instrumentation auto-load
- ただし `OTEL_TRACES_EXPORTER` 等の exporter 指定なしで **default = noop**、 span が emit されず消失
- Tempo / Mimir 到達 0 件 (= Loki log は別経路 = OTel Collector filelog で OK)

## Fix

`services/monolith/kubernetes/base/deployment.yaml` の env block に 4 env vars 追加:
- `OTEL_TRACES_EXPORTER=otlp`
- `OTEL_METRICS_EXPORTER=otlp`
- `OTEL_LOGS_EXPORTER=otlp`
- `OTEL_PROPAGATORS=tracecontext,baggage`

## Post-merge validation

cluster apply 後:
- Tempo で `service.name=monolith` trace 流入確認
- Mimir で `rpc_server_*` / `db_client_*` metrics 流入確認
- frontend → monolith ConnectRPC trace 結合 (= 同 trace_id) 確認

## Related

- Phase 6-2 fix forward (= panicboat/monorepo PR #601): inject-ruby annotation 削除 + env vars hardcode 切替の origin
- Phase 6-3 spec (= panicboat/platform docs/superpowers/specs/2026-05-12-eks-production-application-end-to-end-validation-design.md): 13 checklist application 化 validate
- 引き継ぎ #25 (= OTel Operator chart upgrade): 本 hardcode 撤去 + inject-ruby annotation 復活予定 (= Phase 7 Theme D)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration to enable OpenTelemetry tracing, metrics, and logs exports with proper trace context propagation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/606)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->