### PR TITLE
chore(renovate): track OpenTofu releases for required_version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,6 +65,16 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "Track OpenTofu releases instead of Terraform for required_version",
+      "matchDepTypes": [
+        "required_version"
+      ],
+      "matchDepNames": [
+        "hashicorp/terraform"
+      ],
+      "overridePackageName": "opentofu/opentofu"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `.github/workflows/reusable--terragrunt-executor.yaml` runs OpenTofu via `panicboat/panicboat-actions/terragrunt-run`, not Terraform.
- Without this override, Renovate looks up `hashicorp/terraform` (currently v1.15.3) for `required_version` and would bump constraints past whatever OpenTofu actually supports — the same failure mode that took out 9 PRs on `panicboat/platform` after OpenTofu v1.12.0 released.
- Matches the override already deployed in `panicboat/platform/.github/renovate.json`.

## Why no immediate PR is needed

`monorepo` currently has no open Renovate PRs for `required_version`. This is a latent-bug fix: it prevents the next bump cycle from blowing up.

## Test plan

- [ ] Confirm Renovate dashboard re-evaluates `required_version` entries against OpenTofu (`services/monolith/terragrunt/modules/terraform.tf` is `>= 1.11.0`, would target 1.12.0).
- [ ] Verify no spurious PR for `template/terragrunt/modules/terraform.tf` (currently pinned to `1.15.2`; OpenTofu has no such version — Renovate should not downgrade).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency tracking configuration to prioritize OpenTofu releases over Terraform for version requirement tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->