### PR TITLE
feat(ci): release-please workflow を manifest mode で追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+  "services/monolith": "0.1.0",
+  "services/frontend": "0.1.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "d43ec31de05d1da9767b8fde516328e0356c8a1c",
+  "separate-pull-requests": true,
+  "packages": {
+    "services/monolith": {
+      "release-type": "simple",
+      "component": "monolith",
+      "include-component-in-tag": true
+    },
+    "services/frontend": {
+      "release-type": "simple",
+      "component": "frontend",
+      "include-component-in-tag": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `googleapis/release-please-action@v5` を manifest mode で導入
- monolith / frontend を独立 component として管理 (separate-pull-requests: true)
- 各 component の初期バージョン 0.1.0、release-type: simple (コードベースの version ファイルは更新しない)
- tag 形式: `monolith-v0.X.0` / `frontend-v0.X.0` (Phase 2 で Flux ImagePolicy のソースとして使用予定)
- `bootstrap-sha` は導入 PR のベース main HEAD に固定

## Spec

panicboat/platform リポの `docs/superpowers/specs/2026-05-16-release-please-rollout-design.md` を参照。

## Test plan

- [ ] CI (lint-actions / semantic-pull-request) が通る
- [ ] マージ後、release-please PR が monolith / frontend それぞれ独立に生成される (初回は 2 PR)
- [ ] 各 release-please PR をマージすると、対応する `monolith-v0.1.0` / `frontend-v0.1.0` tag、GitHub Release、CHANGELOG.md (services/monolith/CHANGELOG.md / services/frontend/CHANGELOG.md) が生成される