### PR TITLE
feat: bootstrap release-please path routing (monolith / frontend)

### DIFF
--- a/services/frontend/.release-please-bootstrap
+++ b/services/frontend/.release-please-bootstrap
@@ -1,0 +1,9 @@
+This file exists to bootstrap release-please's path-based commit routing for the
+frontend component. release-please tracks releases per package by inspecting which
+paths each commit touches, so a brand-new component with no prior changes never
+produces a release PR on its own.
+
+After the initial `frontend-v0.1.0` tag is created, remove this file in a follow-up
+PR. The removal commit must use `chore(frontend):` (or any scope routing to
+services/frontend) so release-please attributes the change to the correct component
+on subsequent runs.

--- a/services/monolith/.release-please-bootstrap
+++ b/services/monolith/.release-please-bootstrap
@@ -1,0 +1,9 @@
+This file exists to bootstrap release-please's path-based commit routing for the
+monolith component. release-please tracks releases per package by inspecting which
+paths each commit touches, so a brand-new component with no prior changes never
+produces a release PR on its own.
+
+After the initial `monolith-v0.1.0` tag is created, remove this file in a follow-up
+PR. The removal commit must use `chore(monolith):` (or any scope routing to
+services/monolith) so release-please attributes the change to the correct component
+on subsequent runs.


### PR DESCRIPTION
## Summary

monorepo の release-please は manifest mode + path-based commit routing を採用しているため、`services/monolith/` または `services/frontend/` 配下に変更コミットがないと release-please PR が生成されない。

PR #609 マージ後の検証で「commits: 0」「No commits for path: services/monolith, skipping」「No commits for path: services/frontend, skipping」が観測され、初回 release が打てない状態だった。

本 PR は各 component 配下に sentinel ファイル `.release-please-bootstrap` を追加することで、初回 release-please PR (`monolith-v0.1.0` と `frontend-v0.1.0`) を誘発する。

## Commits

- `feat(monolith):` で `services/monolith/.release-please-bootstrap` を追加 → monolith component に初回 commit を流す
- `feat(frontend):` で `services/frontend/.release-please-bootstrap` を追加 → frontend component に初回 commit を流す

separate-pull-requests: true により、初回 release-please PR は monolith / frontend それぞれ 1 PR ずつ、計 2 PR が生成される想定。

## Follow-up

初回 `monolith-v0.1.0` / `frontend-v0.1.0` tag が作成された後、`.release-please-bootstrap` を削除する追従 PR を出す。削除コミットも `chore(monolith):` / `chore(frontend):` の scope を付けて path 経由で component に紐付けること。

## Test plan

- [ ] CI (lint-actions / semantic-pull-request) が通る
- [ ] マージ後、release-please PR が monolith / frontend それぞれ独立に生成される
- [ ] 各 release-please PR をマージすると `monolith-v0.1.0` / `frontend-v0.1.0` tag、GitHub Release、CHANGELOG.md (services/monolith/CHANGELOG.md と services/frontend/CHANGELOG.md) が生成される
- [ ] sentinel ファイル削除追従 PR を別途出す