### PR TITLE
fix(ci): reset release-please manifest baseline to 0.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "services/monolith": "0.1.0",
-  "services/frontend": "0.1.0"
+  "services/monolith": "0.0.0",
+  "services/frontend": "0.0.0"
 }


### PR DESCRIPTION
## Summary

PR #609 introduced `.release-please-manifest.json` with `"0.1.0"` as the initial value for each component (services/monolith, services/frontend). In release-please's manifest mode, this field represents the **last released version**, not the initial release version. The next release is computed by bumping this baseline based on the Conventional Commits since.

PR #610 added two `feat:` commits (bootstrap markers), which release-please interpreted as a minor bump:

- baseline `0.1.0` + `feat:` → `0.2.0` for both monolith and frontend (PRs #611 / #612, now closed)

This change resets the baseline to `0.0.0` so the next minor bump produces `0.1.0`, matching the originally intended initial release version.

## After merge

release-please should regenerate the per-component PRs:

- `chore(main): release monolith 0.1.0`
- `chore(main): release frontend 0.1.0`

## Follow-up (after initial release tags exist)

The sentinel files `services/{monolith,frontend}/.release-please-bootstrap` will be removed in a separate PR.

## Test plan

- [ ] CI (lint-actions / semantic-pull-request) passes
- [ ] After merge, release-please regenerates two PRs targeting `0.1.0` for each component
- [ ] Merging those PRs produces `monolith-v0.1.0` / `frontend-v0.1.0` tags, GitHub Releases (published), and `services/monolith/CHANGELOG.md` / `services/frontend/CHANGELOG.md`