### PR TITLE
chore(.github): pin opentofu and terragrunt versions in aqua.yaml

### DIFF
--- a/.github/aqua.yaml
+++ b/.github/aqua.yaml
@@ -1,0 +1,10 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+registries:
+  - type: standard
+    ref: v4.311.0 # renovate: github_release aquaproj/aqua-registry
+
+packages:
+  - name: opentofu/opentofu@v1.12.0
+  - name: gruntwork-io/terragrunt@v1.0.2


### PR DESCRIPTION
## Summary

Introduces `.github/aqua.yaml` with `opentofu/opentofu@v1.12.0` and `gruntwork-io/terragrunt@v1.0.2`. Part 1/3 of the rollout in `docs/superpowers/plans/2026-05-16-renovate-tofu-aqua.md` (see panicboat/platform spec PR #414).

No behavior change: the current `panicboat-actions/terragrunt-run` composite reads versions from `gruntwork-io/terragrunt-action` inputs, not from aqua.yaml. This PR lands the source-of-truth file first so the composite migration in panicboat-actions can rely on it without breaking caller CI.

## Test plan

- [ ] yamllint passes
- [ ] CI green (no-op for terragrunt workflow)