### PR TITLE
fix(ci): force initial release to 0.1.0 via release-as per package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,12 +6,14 @@
     "services/monolith": {
       "release-type": "simple",
       "component": "monolith",
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "release-as": "0.1.0"
     },
     "services/frontend": {
       "release-type": "simple",
       "component": "frontend",
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "release-as": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Add `"release-as": "0.1.0"` to each package in `release-please-config.json` to force the initial release tag to be `0.1.0` for both monolith and frontend.

## Why the previous fixes did not work

- **PR #609** (manifest baseline 0.1.0) → release-please bumped `feat:` to 0.2.0 (PRs #611, #612 closed).
- **PR #613** (manifest baseline 0.0.0) → release-please treats 0.0.0 as "no prior release" and defaults the first release to 1.0.0 (PRs #615, #616 closed).

`release-as` per package is the same mechanism panicboat-actions and platform use (via workflow `with:`). It explicitly pins the next release version regardless of commit-based bump rules.

## Follow-up (REQUIRED)

After `monolith-v0.1.0` and `frontend-v0.1.0` tags are created, **a follow-up PR must remove these `release-as` fields**. If left in place, release-please will continue forcing every release back to `0.1.0`.

## Test plan

- [ ] CI (lint-actions / semantic-pull-request / CI Gatekeeper) passes
- [ ] After merge, release-please regenerates per-component PRs titled `chore(main): release monolith 0.1.0` / `chore(main): release frontend 0.1.0`
- [ ] Merging those PRs produces `monolith-v0.1.0` / `frontend-v0.1.0` tags, GitHub Releases (published), and CHANGELOG.md per service
- [ ] Follow-up PR removes `release-as` from both packages in config