### PR TITLE
chore(ci): remove release-please bootstrap markers and release-as overrides

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,14 +6,12 @@
     "services/monolith": {
       "release-type": "simple",
       "component": "monolith",
-      "include-component-in-tag": true,
-      "release-as": "0.1.0"
+      "include-component-in-tag": true
     },
     "services/frontend": {
       "release-type": "simple",
       "component": "frontend",
-      "include-component-in-tag": true,
-      "release-as": "0.1.0"
+      "include-component-in-tag": true
     }
   }
 }

--- a/services/frontend/.release-please-bootstrap
+++ b/services/frontend/.release-please-bootstrap
@@ -1,9 +1,0 @@
-This file exists to bootstrap release-please's path-based commit routing for the
-frontend component. release-please tracks releases per package by inspecting which
-paths each commit touches, so a brand-new component with no prior changes never
-produces a release PR on its own.
-
-After the initial `frontend-v0.1.0` tag is created, remove this file in a follow-up
-PR. The removal commit must use `chore(frontend):` (or any scope routing to
-services/frontend) so release-please attributes the change to the correct component
-on subsequent runs.

--- a/services/monolith/.release-please-bootstrap
+++ b/services/monolith/.release-please-bootstrap
@@ -1,9 +1,0 @@
-This file exists to bootstrap release-please's path-based commit routing for the
-monolith component. release-please tracks releases per package by inspecting which
-paths each commit touches, so a brand-new component with no prior changes never
-produces a release PR on its own.
-
-After the initial `monolith-v0.1.0` tag is created, remove this file in a follow-up
-PR. The removal commit must use `chore(monolith):` (or any scope routing to
-services/monolith) so release-please attributes the change to the correct component
-on subsequent runs.


### PR DESCRIPTION
## Summary

Cleanup of the one-time bootstrap mechanisms used to get the initial \`monolith-v0.1.0\` and \`frontend-v0.1.0\` releases out:

1. Delete \`services/monolith/.release-please-bootstrap\` (the sentinel that triggered the initial monolith release).
2. Delete \`services/frontend/.release-please-bootstrap\` (the sentinel that triggered the initial frontend release).
3. Remove \`release-as: \"0.1.0\"\` from each package in \`release-please-config.json\`.

## Why this is required

Without removing the \`release-as\` pins, every subsequent release would be forced back to \`0.1.0\` for both components, blocking real version bumps. The sentinel files served only to trigger the very first release-please PR per component (release-please uses path-based commit routing in manifest mode); they have no runtime effect.

## Commit structure

Three separate commits with scoped messages so release-please routes each correctly:

- \`chore(monolith):\` removes monolith marker → routed to services/monolith
- \`chore(frontend):\` removes frontend marker → routed to services/frontend
- \`chore(ci):\` removes release-as overrides → not routed to any component

\`chore:\` does not trigger a bump by default, so this PR should not produce any release-please PR after merge.

## Test plan

- [ ] CI (lint-actions / semantic-pull-request / CI Gatekeeper) passes
- [ ] After merge, release-please does NOT create new release PRs (only chore commits since latest tags, and no release-as pins anymore)
- [ ] Next \`feat:\` / \`fix:\` commit under \`services/monolith\` produces a release-please PR bumping from \`0.1.0\` (e.g. to \`0.2.0\` for feat)
- [ ] Same for \`services/frontend\`