### PR TITLE
chore(monolith/terragrunt): rename envs/develop → envs/production

### DIFF
--- a/services/monolith/terragrunt/envs/production/env.hcl
+++ b/services/monolith/terragrunt/envs/production/env.hcl
@@ -1,11 +1,11 @@
-# env.hcl - Development environment configuration
+# env.hcl - Production environment configuration
 locals {
   # Environment metadata
-  environment = "develop"
+  environment = "production"
   aws_region  = "ap-northeast-1"
-  # Develop-specific resource tags
+  # Production-specific resource tags
   additional_tags = {
-    CostCenter   = "develop"
+    CostCenter   = "production"
     Owner        = "panicboat"
     Purpose      = "monolith"
     AutoShutdown = "enabled"

--- a/services/monolith/terragrunt/envs/production/terragrunt.hcl
+++ b/services/monolith/terragrunt/envs/production/terragrunt.hcl
@@ -34,7 +34,7 @@ inputs = {
     },
     include.env.locals.additional_tags
   )
-  db_identifier          = "monolith-develop"
-  db_subnet_group_name   = "monolith-develop"
-  db_security_group_name = "monolith-database-develop"
+  db_identifier          = "monolith-production"
+  db_subnet_group_name   = "monolith-production"
+  db_security_group_name = "monolith-database-production"
 }


### PR DESCRIPTION
## Summary

monorepo の env 命名 single-env (= production) への統一の一環として、 monolith terragrunt env も rename。 AWS resource は事前 destroy 不要 (= 旧 develop env で実 provision 未済、 S3 state 153 byte の空 state、 RDS instance / Secret も AWS 上に実体不在) で、 新 production env で fresh apply する形で migration。

## Changes

- `services/monolith/terragrunt/envs/develop → envs/production` rename
- `envs/production/env.hcl` の `environment = "develop"` → `"production"`、 `CostCenter` additional_tag も `"develop"` → `"production"`
- `envs/production/terragrunt.hcl` の inputs `db_identifier` / `db_subnet_group_name` / `db_security_group_name` を `"develop"` → `"production"`

## Pre-PR operations (= 完了済)

- S3 旧 state file (`services/monolith/develop/terraform.tfstate`) 削除 (= 153 byte 空 state)
- `terragrunt apply` で fresh provision 進行中 (= 別 task で `/tmp/monolith-prod.tfplan` 経由)

## Resources provisioned (= apply 完了後)

- `aws_db_instance.monolith` (= `monolith-production`、 PostgreSQL 17.4 db.t4g.micro)
- `aws_db_subnet_group.monolith` (= `monolith-production`)
- `aws_security_group.monolith_db` (= `monolith-database-production`、 5432 from VPC private subnets)
- `aws_security_group_rule.monolith_db_ingress`
- `aws_secretsmanager_secret.monolith_database` (= `panicboat/monolith/database`、 value 不在 container のみ)
- `random_password.monolith_db_master`

## User manual action 必要

apply 完了後、 AWS Secrets Manager `panicboat/monolith/database` に value を put-secret-value:

```bash
aws secretsmanager put-secret-value \
  --secret-id panicboat/monolith/database \
  --secret-string '{"username":"postgres","password":"<rds-master-pw>","host":"<rds-endpoint>","port":5432,"database":"monolith","url":"postgres://..."}'
```

value inject 後 ESO `ExternalSecret monolith-database` が AWS から sync → K8s Secret `monolith-database` 作成 → monolith Pod の `CreateContainerConfigError` 解消の見込み。

## Note

- user の WIP (`services/monolith/terragrunt/modules/main.tf` + `outputs.tf` modified) は本 PR と独立、 別 commit / PR で処理
- 本 PR は monorepo PR #621 (= K8s overlays rename) と connecting 関係なし (= 別 concern、 独立 review 可)

## Test plan

- [x] `terragrunt plan` で 6 to add / 0 destroy 確認 (= 手元 verify 済)
- [x] `terragrunt apply` 開始 (= background task で進行中)
- [ ] apply 完了確認 + AWS RDS instance `monolith-production` Status=available
- [ ] user manual で Secrets Manager value inject 後、 monolith Pod が ESO 経由 Running 復活