### PR TITLE
feat(flux): cut over production deploy to semver image tags

### DIFF
--- a/clusters/production/services/frontend/image-automation.yaml
+++ b/clusters/production/services/frontend/image-automation.yaml
@@ -21,5 +21,5 @@ spec:
     push:
       branch: main
   update:
-    path: ./services/frontend/kubernetes
+    path: ./services/frontend/kubernetes/overlays/production
     strategy: Setters

--- a/clusters/production/services/frontend/image-policy.yaml
+++ b/clusters/production/services/frontend/image-policy.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   imageRepositoryRef:
     name: frontend
-  digestReflectionPolicy: Always
   interval: 10m
   filterTags:
-    pattern: '^latest$'
+    pattern: '^v(?P<version>\d+\.\d+\.\d+)$'
+    extract: '$version'
   policy:
-    alphabetical:
-      order: asc
+    semver:
+      range: '>=0.0.0'

--- a/clusters/production/services/monolith/image-automation.yaml
+++ b/clusters/production/services/monolith/image-automation.yaml
@@ -21,5 +21,5 @@ spec:
     push:
       branch: main
   update:
-    path: ./services/monolith/kubernetes
+    path: ./services/monolith/kubernetes/overlays/production
     strategy: Setters

--- a/clusters/production/services/monolith/image-policy.yaml
+++ b/clusters/production/services/monolith/image-policy.yaml
@@ -1,10 +1,9 @@
 # =============================================================================
-# ImagePolicy for monolith (= digest reflection pattern)
+# ImagePolicy for monolith (= semver tag pattern)
 # =============================================================================
-# Flux v1.1.1 の digestReflectionPolicy: Always で latest tag の digest を
-# auto-track。 sha tag (= deploy-actions container-builder の type=sha
-# default short 7chars) は random で alphabetical / numerical order で
-# 最新 pick 不可のため、 latest tag pin + digest reflection を採用。
+# release-please tag (monolith-vX.Y.Z) を起点に build される ghcr semver tag
+# (vX.Y.Z) を Flux が pickup する。 main push 由来の latest / sha tag は
+# filterTags pattern で除外される (= Flux が見るのは semver のみ)。
 # =============================================================================
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
@@ -16,10 +15,10 @@ metadata:
 spec:
   imageRepositoryRef:
     name: monolith
-  digestReflectionPolicy: Always
   interval: 10m
   filterTags:
-    pattern: '^latest$'
+    pattern: '^v(?P<version>\d+\.\d+\.\d+)$'
+    extract: '$version'
   policy:
-    alphabetical:
-      order: asc
+    semver:
+      range: '>=0.0.0'

--- a/services/frontend/kubernetes/base/deployment.yaml
+++ b/services/frontend/kubernetes/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: ghcr.io/panicboat/monorepo/frontend:latest # {"$imagepolicy": "flux-system:frontend"}
+          image: ghcr.io/panicboat/monorepo/frontend:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/services/frontend/kubernetes/overlays/production/deployment.yaml
+++ b/services/frontend/kubernetes/overlays/production/deployment.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/panicboat/monorepo/frontend:v0.1.0 # {"$imagepolicy": "flux-system:frontend"}

--- a/services/frontend/kubernetes/overlays/production/kustomization.yaml
+++ b/services/frontend/kubernetes/overlays/production/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ../../base
 patches:
   - path: configmap.yaml
+  - path: deployment.yaml

--- a/services/monolith/kubernetes/base/deployment.yaml
+++ b/services/monolith/kubernetes/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: monolith
-          image: ghcr.io/panicboat/monorepo/monolith:latest # {"$imagepolicy": "flux-system:monolith"}
+          image: ghcr.io/panicboat/monorepo/monolith:latest
           imagePullPolicy: IfNotPresent
           command: ["./bin/start"]
           ports:

--- a/services/monolith/kubernetes/overlays/production/deployment.yaml
+++ b/services/monolith/kubernetes/overlays/production/deployment.yaml
@@ -1,0 +1,17 @@
+# =============================================================================
+# Deployment patch for monolith (production overlay)
+# =============================================================================
+# Flux ImageUpdateAutomation (= Setters strategy) が image 行を semver tag に
+# 書き換える対象。 base/deployment.yaml は :latest を保持するが、 production
+# cluster では本 patch で必ず上書きされる。
+# =============================================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monolith
+spec:
+  template:
+    spec:
+      containers:
+        - name: monolith
+          image: ghcr.io/panicboat/monorepo/monolith:v0.1.0 # {"$imagepolicy": "flux-system:monolith"}

--- a/services/monolith/kubernetes/overlays/production/kustomization.yaml
+++ b/services/monolith/kubernetes/overlays/production/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - external-secret.yaml
 patches:
   - path: configmap.yaml
+  - path: deployment.yaml


### PR DESCRIPTION
## Summary

PR 2 of 2 for the release-driven Flux deploy rollout (spec: `docs/superpowers/specs/2026-05-17-release-driven-flux-deploy-design.md`).

Cutover from `:latest` + digest reflection to semver tag deploy:

- **Flux** (`clusters/production/services/{monolith,frontend}/`):
  - `image-policy.yaml`: replace latest filter with semver filter + semver policy
  - `image-automation.yaml`: narrow `update.path` to `overlays/production`
- **Kustomize** (`services/{monolith,frontend}/kubernetes/`):
  - `base/deployment.yaml`: drop Setters annotation (`:latest` is kept)
  - `overlays/production/deployment.yaml` (new): strategic merge patch pinning `:v0.1.0` + Setters annotation
  - `overlays/production/kustomization.yaml`: add the new deployment patch

## Prerequisite

PR 1 (#623) merged. `ghcr.io/panicboat/monorepo/{monolith,frontend}:v0.1.0` exist (built via workflow_dispatch after PR 1 merge).

## Test plan

- [ ] CI (lint-actions / semantic-pull-request / CI Gatekeeper) passes
- [ ] `kubectl get imagepolicy -n flux-system monolith -o jsonpath='{.status.latestImage}'` returns `ghcr.io/panicboat/monorepo/monolith:v0.1.0` (same for frontend)
- [ ] Flux ImageUpdateAutomation rewrites `overlays/production/deployment.yaml` if needed and pushes the commit
- [ ] `kubectl rollout status deployment/monolith` (and frontend) completes
- [ ] Next release-please cycle (e.g. monolith-v0.2.0) triggers PR 1's auto-release--trigger.yaml end-to-end