### PR TITLE
chore(frontend): switch HTTPRoute hostname to dystopia.city

### DIFF
--- a/services/frontend/kubernetes/base/httproute.yaml
+++ b/services/frontend/kubernetes/base/httproute.yaml
@@ -1,5 +1,5 @@
 # Cilium Gateway (= namespace default、 listener http:8080) を parentRef、
-# host develop.panicboat.net への traffic を frontend Service:80 に backend
+# host dystopia.city (apex) への traffic を frontend Service:80 に backend
 # する。 ingress 経路: client → ALB (= application IngressGroup、 platform 側
 # kubernetes/components/cilium/) → cilium-envoy hostNetwork :8080 → 本
 # HTTPRoute → frontend。
@@ -13,7 +13,7 @@ spec:
     - name: cilium-gateway
       namespace: default
   hostnames:
-    - develop.panicboat.net
+    - dystopia.city
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary

frontend HTTPRoute hostname を `develop.panicboat.net` → `dystopia.city` (apex) に切替。 引き継ぎ事項 #33 の dystopia.city 公開部分。

## Related

- platform PR (= ALB IngressGroup 統合 + ACM cert + ExternalDNS): https://github.com/panicboat/platform/pull/433
- spec: https://github.com/panicboat/platform/blob/main/docs/superpowers/specs/2026-05-17-dystopia-city-migration-design.md

## Merge order

1. platform PR #433 merge
2. 本 PR merge
3. Flux reconcile で HTTPRoute 反映、 dystopia.city 経由 application 動作開始