### PR TITLE
fix(flux/image-policy): drop spec.interval (= digestReflection 廃止 follow-up)

### DIFF
--- a/clusters/production/services/frontend/image-policy.yaml
+++ b/clusters/production/services/frontend/image-policy.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   imageRepositoryRef:
     name: frontend
-  interval: 10m
   filterTags:
     pattern: '^v(?P<version>\d+\.\d+\.\d+)$'
     extract: '$version'

--- a/clusters/production/services/monolith/image-policy.yaml
+++ b/clusters/production/services/monolith/image-policy.yaml
@@ -15,7 +15,6 @@ metadata:
 spec:
   imageRepositoryRef:
     name: monolith
-  interval: 10m
   filterTags:
     pattern: '^v(?P<version>\d+\.\d+\.\d+)$'
     extract: '$version'


### PR DESCRIPTION
## Summary

PR #624 (= `feat(flux): cut over production deploy to semver image tags`) で `digestReflectionPolicy: Always` を削除して semver tag tracking に切替、 ただし `spec.interval: 10m` を削除し忘れ、 ImagePolicy v1 schema validation で reject:

> ImagePolicy.image.toolkit.fluxcd.io "monolith" is invalid: spec: Invalid value: spec.interval is only accepted when spec.digestReflectionPolicy is set to 'Always'

cluster で monorepo-cluster Kustomization が **READY=False で stuck**、 ImageRepository / ImagePolicy / ImageUpdateAutomation の reconcile 停止 (= 新 release image push でも deployment.yaml の image bump 起きない state)。

## Fix

monolith + frontend 両 `image-policy.yaml` の `interval: 10m` 行を削除。 schema pass で reconcile 復活。

## Test plan

- [ ] PR merge 後 cluster で `kubectl get kustomization monorepo-cluster -n flux-system` が READY=True に
- [ ] `kubectl get imagepolicy -n flux-system` で monolith + frontend が Ready
- [ ] 次 release-please tag push → image auto-bump 動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image update check configuration for production services to use default polling settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->