### PR TITLE
fix(frontend): align gRPC backend env name with code

### DIFF
--- a/services/frontend/kubernetes/overlays/production/configmap.yaml
+++ b/services/frontend/kubernetes/overlays/production/configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: frontend
 data:
   NODE_ENV: development
-  GRPC_BACKEND_URL: http://monolith:9001
+  MONOLITH_URL: http://monolith:9001


### PR DESCRIPTION
## Summary

- `src/lib/grpc.ts` reads `process.env.MONOLITH_URL`, but the production ConfigMap was exposing `GRPC_BACKEND_URL`
- The mismatch left `MONOLITH_URL` undefined → the `FALLBACK` at `http://localhost:9001` took over → nothing is listening there
- Every BFF gRPC call therefore returned code 14 (UNAVAILABLE), surfacing in the browser as `POST /api/identity/send-sms 500` with frontend logs of `[SendSms] gRPC error (14):`

## Evidence

```
$ kubectl exec -n default deploy/frontend -- printenv | grep -i monolith
GRPC_BACKEND_URL=http://monolith:9001   # set but never read by code
MONOLITH_SERVICE_HOST=172.20.179.88     # k8s autogen, not read by code
# (no MONOLITH_URL)
```

`grep -rn GRPC_BACKEND_URL` finds the key only in the production overlay's ConfigMap — no source file references it.

## Test plan

- [ ] Flux reconciles the ConfigMap
- [ ] Stakater Reloader rolls out `deploy/frontend` (`reloader.stakater.com/auto: "true"` already set)
- [ ] `kubectl exec deploy/frontend -- printenv MONOLITH_URL` shows `http://monolith:9001`
- [ ] Browser: login button on `https://dystopia.city/` no longer 500s, `/api/identity/send-sms` succeeds