### PR TITLE
fix(monolith): make unify_user_id migration idempotent and stop silencing migrate failures

### DIFF
--- a/services/monolith/workspace/bin/start
+++ b/services/monolith/workspace/bin/start
@@ -8,7 +8,7 @@ echo "Running migrations..."
 # Check if hanami exists before running
 if [ -f "Gemfile" ]; then
   bundle exec hanami db create
-  bundle exec hanami db migrate || echo "Migration failed (possibly no migrations), continuing..."
+  bundle exec hanami db migrate
 else
   echo "Gemfile not found, skipping migrations."
 fi

--- a/services/monolith/workspace/config/db/migrate/20260227000001_unify_user_id.rb
+++ b/services/monolith/workspace/config/db/migrate/20260227000001_unify_user_id.rb
@@ -195,7 +195,7 @@ ROM::SQL.migration do
 
     run <<-SQL
       ALTER TABLE offer.plans
-      DROP CONSTRAINT cast_plans_cast_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_plans_cast_id_not_null;
     SQL
 
     run <<-SQL
@@ -239,7 +239,7 @@ ROM::SQL.migration do
 
     run <<-SQL
       ALTER TABLE offer.schedules
-      DROP CONSTRAINT cast_schedules_cast_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_schedules_cast_id_not_null;
     SQL
 
     run <<-SQL
@@ -283,7 +283,7 @@ ROM::SQL.migration do
 
     run <<-SQL
       ALTER TABLE post.posts
-      DROP CONSTRAINT cast_posts_cast_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_posts_cast_id_not_null;
     SQL
 
     run <<-SQL
@@ -332,7 +332,7 @@ ROM::SQL.migration do
 
     run <<-SQL
       ALTER TABLE post.likes
-      DROP CONSTRAINT post_likes_guest_id_not_null;
+      DROP CONSTRAINT IF EXISTS post_likes_guest_id_not_null;
     SQL
 
     run <<-SQL
@@ -398,12 +398,12 @@ ROM::SQL.migration do
 
     run <<-SQL
       ALTER TABLE relationship.follows
-      DROP CONSTRAINT cast_follows_cast_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_follows_cast_id_not_null;
     SQL
 
     run <<-SQL
       ALTER TABLE relationship.follows
-      DROP CONSTRAINT cast_follows_guest_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_follows_guest_id_not_null;
     SQL
 
     run <<-SQL
@@ -476,12 +476,12 @@ ROM::SQL.migration do
 
     run <<-SQL
       ALTER TABLE relationship.favorites
-      DROP CONSTRAINT cast_favorites_cast_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_favorites_cast_id_not_null;
     SQL
 
     run <<-SQL
       ALTER TABLE relationship.favorites
-      DROP CONSTRAINT cast_favorites_guest_id_not_null;
+      DROP CONSTRAINT IF EXISTS cast_favorites_guest_id_not_null;
     SQL
 
     run <<-SQL


### PR DESCRIPTION
## Summary

- `20260227000001_unify_user_id.rb` tries to `DROP CONSTRAINT cast_plans_cast_id_not_null` (and 7 similarly-named `*_not_null` CHECK constraints) that have never existed in production: NOT NULL on those tables was only ever a column-level constraint, not a named CHECK
- The first match raised `PG::UndefinedObject`, the in-transaction migration rolled back, and no part of `unify_user_id` was applied
- `bin/start` then swallowed the migrate failure with `|| echo "... continuing..."`, so the gRPC server came up against an inconsistent schema with no visible signal — `set -e` was bypassed by the `||` arm

## Changes

- Add `IF EXISTS` to the 8 `DROP CONSTRAINT xxx_not_null` statements (lines 198, 242, 286, 335, 401, 406, 479, 484). Other `DROP CONSTRAINT` calls for `fkey`/`pkey`/`_key` are kept strict because those constraints do exist
- Remove the silent fallback in `bin/start` so migrate failures now CrashLoopBackOff the pod and are visible immediately. Matches CLAUDE.md's ban on silent error handling

## Evidence

Production DB (current state):

```sql
SELECT count(*) FROM pg_constraint c
JOIN pg_namespace n ON n.oid = c.connamespace
WHERE n.nspname IN ('portfolio','offer','trust','post','relationship')
  AND c.conname LIKE '%_not_null';
-- 0 rows
```

`schema_migrations` stops at `20260226000001`, and no `cast_user_id` column exists in any schema — confirming the migration was fully rolled back.

## Note

This is **not** the cause of the current `/api/identity/send-sms` UNAVAILABLE failures (those are addressed in #633). This PR fixes a latent migration bug and the silent-failure footgun that hid it.

## Test plan

- [ ] CI passes
- [ ] Local docker-compose: `bundle exec hanami db migrate` runs the unify_user_id migration to completion
- [ ] After Flux rollout: `kubectl logs deploy/monolith` shows no "Migration failed ... continuing..." line
- [ ] `schema_migrations` includes `20260227000001_unify_user_id.rb`
- [ ] If migration ever fails again, pod CrashLoopBackOffs (verified by intentionally breaking a migration in a follow-up local test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup process now halts properly if database migrations fail instead of continuing silently.
  * Database migrations enhanced with improved constraint handling to prevent errors when constraints are absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->