### PR TITLE
chore(frontend): set NODE_ENV=production in production overlay

### DIFF
--- a/services/frontend/kubernetes/overlays/production/configmap.yaml
+++ b/services/frontend/kubernetes/overlays/production/configmap.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: frontend
 data:
-  NODE_ENV: development
+  NODE_ENV: production
   MONOLITH_URL: http://monolith:9001


### PR DESCRIPTION
## Summary

- Dockerfile's runner stage already declares `ENV NODE_ENV=production`, but the production overlay's ConfigMap exposes `NODE_ENV: development`
- `envFrom` overrides the Dockerfile default, so the runtime serves the production build under dev-mode React/Next semantics (verbose warnings, dev-only invariants, unminified error messages)

## Why this is safe

- `grep -rn "process.env.NODE_ENV" src/` returns 0 matches → no app-level branches depend on `NODE_ENV`
- Affects only React/Next.js internals and third-party libraries (SWR, OpenTelemetry, Connect-RPC) that switch behavior on `NODE_ENV`
- The standalone build itself is identical (built in builder stage)
- Reloader (`reloader.stakater.com/auto: "true"`) will roll out the deploy automatically — no image rebuild required

## Test plan

- [ ] Flux reconciles the ConfigMap
- [ ] Stakater Reloader rolls out `deploy/frontend`
- [ ] `kubectl exec deploy/frontend -- printenv NODE_ENV` shows `production`
- [ ] Login flow on https://dystopia.city/ still works end-to-end (regression check)