### PR TITLE
chore(frontend): drop redundant NODE_ENV from production overlay

### DIFF
--- a/services/frontend/kubernetes/overlays/production/configmap.yaml
+++ b/services/frontend/kubernetes/overlays/production/configmap.yaml
@@ -3,5 +3,4 @@ kind: ConfigMap
 metadata:
   name: frontend
 data:
-  NODE_ENV: development
   MONOLITH_URL: http://monolith:9001


### PR DESCRIPTION
## Summary

- `services/frontend/workspace/Dockerfile` runner stage already declares `ENV NODE_ENV=production`
- The production overlay's ConfigMap was setting `NODE_ENV: development`, which envFrom overrides the Dockerfile default with — leaving the production build loaded under dev-mode React/Next semantics
- Removing the key entirely keeps the runtime mode owned by a single source (the Dockerfile)

## Why this is safe

- `grep -rn "process.env.NODE_ENV" src/` returns 0 matches → no app-level branches
- After the change, `kubectl exec deploy/frontend -- printenv NODE_ENV` will read `production` from the Dockerfile layer
- Reloader (`reloader.stakater.com/auto: "true"`) rolls out automatically; no image rebuild required

## Test plan

- [ ] Flux reconciles the ConfigMap
- [ ] Stakater Reloader rolls out `deploy/frontend`
- [ ] `kubectl exec deploy/frontend -- printenv NODE_ENV` shows `production`
- [ ] Login flow on https://dystopia.city/ still works end-to-end (regression check)