### PR TITLE
chore(monolith): own HANAMI_ENV in the Dockerfile

### DIFF
--- a/services/monolith/kubernetes/overlays/production/configmap.yaml
+++ b/services/monolith/kubernetes/overlays/production/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: monolith
-data:
-  HANAMI_ENV: development

--- a/services/monolith/kubernetes/overlays/production/kustomization.yaml
+++ b/services/monolith/kubernetes/overlays/production/kustomization.yaml
@@ -4,5 +4,4 @@ resources:
   - ../../base
   - external-secret.yaml
 patches:
-  - path: configmap.yaml
   - path: deployment.yaml

--- a/services/monolith/workspace/Dockerfile
+++ b/services/monolith/workspace/Dockerfile
@@ -37,6 +37,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /app
 ENV BUNDLE_PATH=/usr/local/bundle
+ENV HANAMI_ENV=production
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY . .
 


### PR DESCRIPTION
## Summary

- The production overlay's ConfigMap exposed `HANAMI_ENV: development`, but this value only reached `bundle exec hanami db migrate` in `bin/start`
- `bin/grpc:6` rewrites `ENV["HANAMI_ENV"] = "production"` before `Hanami.app.boot`, so the gRPC server was already running under production semantics
- The overlay key was therefore a dead configuration that contradicted the runtime reality

## Changes

- Add `ENV HANAMI_ENV=production` to the runner stage of `services/monolith/workspace/Dockerfile` so the Hanami environment has a single source of truth at the image level
- Drop the production overlay's ConfigMap patch entirely (`configmap.yaml` and its entry in `kustomization.yaml`); the base ConfigMap (`data: {}`) is sufficient

## Why this is safe

`grep` for `Hanami.env` / `HANAMI_ENV` reveals only:

- `config/app.rb:12` — `Hanami.env?(:development)` gates a dev-only middleware (LocalUploader); already inactive in production
- `config/puma.rb:7` — only reached by `hanami server` / puma; not used by the gRPC entrypoint
- `spec/spec_helper.rb:8` — `HANAMI_ENV ||= "test"`, untouched
- `docker-compose.yaml:11` — local dev override, untouched

Behavior matrix after this change:

| Path | Before | After |
|---|---|---|
| k8s prod: `hanami db migrate` (via bin/start) | `development` (ConfigMap) | **`production`** (Dockerfile) — fixes the only meaningful divergence |
| k8s prod: bin/grpc | `production` (hard-coded) | `production` (hard-coded; Dockerfile matches) |
| local docker-compose | `development` (compose) | `development` (compose) |
| spec | `test` | `test` |

## Note on `bin/grpc:6`

`bin/grpc:6` keeps its `ENV["HANAMI_ENV"] = "production"` override for now: it is part of the local-production-mode trio (with `BUNDLE_WITHOUT` and the `SECRET_KEY_BASE` default) and is harmless given the Dockerfile already pins the same value. Worth revisiting as a separate cleanup if/when that trio is refactored.

## Test plan

- [ ] CI image build succeeds
- [ ] Flux reconciles the new image / Kustomization
- [ ] `kubectl exec deploy/monolith -- printenv HANAMI_ENV` shows `production`
- [ ] `kubectl logs deploy/monolith` after rollout: migrations run under production (no `development` references in startup logs); gRPC server starts; existing RPCs continue to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment environment configuration to align with current infrastructure requirements.
  * Simplified deployment configuration by removing redundant patches and outdated settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->