### PR TITLE
chore(ci): disable Terragrunt deploy job and drop unused cleanup-container block

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -58,6 +58,7 @@ jobs:
     if: |
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"terragrunt"')
+      && true == 'false' # TODO: Terragrunt deployment is currently disabled as we have no active Terragrunt targets; re-enable when needed by removing this line
     strategy:
       matrix:
         target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
@@ -114,28 +115,6 @@ jobs:
       app-id: ${{ vars.APP_ID }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-  # cleanup-container:
-  #   name: 'Cleanup Container'
-  #   needs: deploy-trigger
-  #   runs-on: ubuntu-latest
-  #   if: |
-  #     needs.deploy-trigger.outputs.has-targets == 'true' &&
-  #     contains(needs.deploy-trigger.outputs.targets, '"stack":"docker"')
-  #   strategy:
-  #     matrix:
-  #       target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}
-  #     fail-fast: false
-  #   steps:
-  #     - name: Cleanup container
-  #       uses: dataaxiom/ghcr-cleanup-action@v1.0.16
-  #       if: matrix.target.stack == 'docker'
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         package: monorepo/${{ matrix.target.service }}
-  #         keep-n-untagged: 0
-  #         use-regex: true
-  #   continue-on-error: true
 
   deployment-summary:
     name: 'Deployment Summary'


### PR DESCRIPTION
## Summary
- Gate the `deploy-terragrunt` job off with a constant-false guard while there are no active Terragrunt targets in this repo.
- Remove the long-commented `cleanup-container` job that has no live callers; trim dead code from `.github/workflows/auto-label--deploy-trigger.yaml`.

## Test Plan
- [ ] Workflow YAML parses without syntax errors (GitHub Actions linter)
- [ ] On a deploy-trigger event with `stack: terragrunt`, the `deploy-terragrunt` job is skipped
- [ ] On a deploy-trigger event with `stack: kubernetes`/`docker`, the other jobs still run unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Terragrunt-based deployments in the deployment workflow
  * Removed cleanup container job from the deployment process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->