### PR TITLE
chore: remove unused Terragrunt stack convention and disable guard

### DIFF
--- a/.github/workflows/auto-label--deploy-trigger.yaml
+++ b/.github/workflows/auto-label--deploy-trigger.yaml
@@ -58,7 +58,6 @@ jobs:
     if: |
       needs.deploy-trigger.outputs.has-targets == 'true' &&
       contains(needs.deploy-trigger.outputs.targets, '"stack":"terragrunt"')
-      && true == 'false' # TODO: Terragrunt deployment is currently disabled as we have no active Terragrunt targets; re-enable when needed by removing this line
     strategy:
       matrix:
         target: ${{ fromJson(needs.deploy-trigger.outputs.targets) }}

--- a/workflow-config.yaml
+++ b/workflow-config.yaml
@@ -11,8 +11,9 @@ stack_conventions:
     stacks:
       - name: docker
         directory: workspace
-      - name: terragrunt
-        directory: terragrunt/envs/{environment}
-        required_attributes: [aws_region, iam_role_plan, iam_role_apply]
+      # TODO: Define conventions for Terragrunt stacks when we have active Terragrunt targets.
+      # - name: terragrunt
+      #   directory: terragrunt/envs/{environment}
+      #   required_attributes: [aws_region, iam_role_plan, iam_role_apply]
       - name: kubernetes
         directory: kubernetes/overlays/{environment}


### PR DESCRIPTION
## Summary

- Comment out the Terragrunt entry in `stack_conventions` of `workflow-config.yaml` because no active Terragrunt targets exist in this repo.
- Drop the redundant `&& true == 'false'` guard on the Terragrunt deploy job in `.github/workflows/auto-label--deploy-trigger.yaml`. With the convention removed, no targets carry `stack="terragrunt"`, so the outer `contains(..., '"stack":"terragrunt"')` check already gates the job; the extra guard becomes unnecessary.

## Test plan

- [ ] Open a PR that touches a non-Terragrunt path and confirm the Terragrunt deploy job is skipped (no targets generated).
- [ ] Confirm Docker / Kubernetes deploy paths are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to enable Terragrunt deployments when applicable conditions are met.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/panicboat/monorepo/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->