### PR TITLE
feat(posts): symmetric posts frontend (Q4: data layer + UI)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-posts-q4a-frontend-data-layer.md
+++ b/docs/superpowers/plans/2026-06-08-posts-q4a-frontend-data-layer.md
@@ -1,0 +1,795 @@
+# Posts Q4a: frontend data layer (BFF + types + mappers + hooks) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** symmetric Post / Like (account-authored) の **data 層**を frontend に追加する: `PostView` + mappers + BFF route handlers (`/api/posts` 配下) + SWR / pagination hooks。UI（ページ・コンポーズ・PostCard binding）は Q4b。
+
+**Architecture:** **Additive、build-green**。新 `PostService` / `LikeService` の symmetric RPC（`ListPosts` / `GetPost` / `SavePost` / `DeletePost` / `LikePost` / `UnlikePost` / `GetLikeStatus`）を消費する純粋な配線。旧 `useCastPosts` / `useLike` / `useTimeline` と `/api/cast/timeline` / `/api/guest/likes` BFF は**無改変**（feed スライス・/dev が依存中、cleanup フェーズで剥がす）。connect-node client は server 専用（route handler）、hooks は `"use client"` で BFF route を `authFetch` / SWR で叩く（profile P5a 完全踏襲）。
+
+**Tech Stack:** Next.js 16 / React 19 / TypeScript / connect-es（`@connectrpc/connect` + `@connectrpc/connect-node`） / SWR / pnpm。
+
+**Spec:** `docs/superpowers/specs/2026-06-07-posts-slice-design.md`（§API contract / §Frontend）。前提: Q1（symmetric proto stub 生成済、`Post` / `PostAuthor` / `PostMedia` / `LikePost*` / `GetLikeStatus*` 全て stub 存在）、Q3 / Q3b（backend symmetric PostService / LikeService 実装済、main マージ済 PR #652）。
+
+---
+
+## Context for the implementer
+
+- worktree（ここの中だけ編集）: `/Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-posts-frontend`。frontend app root: `services/frontend/workspace`。branch `feat/posts-frontend`（origin/main base、tracking 設定済）。**push しない・PR 作らない**（plan 完了後に親が判断）。
+- 検索は **`/usr/bin/grep`** / `/usr/bin/find`（bare `grep` が不安定なため）。import alias `@/` → `src/`。
+- **テストランナーは無い**（`package.json` に test script 無し、vitest/jest 無し）。検証は **`pnpm build`（= next build の型チェック）+ `pnpm lint`**、途中確認は **`pnpm exec tsc --noEmit`**。ユニットテストランナーは**追加しない**（未依頼の依存追加を避ける。mapper は純関数で型が主担保）。
+- `pnpm build` は backend / DB を必要としない（型チェック + バンドルのみ、route は実行されない）。
+- **build-green / additive**: 以下は**触らない**:
+  - `src/modules/post/types.ts`（`CastPost` などの旧型）
+  - `src/modules/post/lib/mappers.ts` / `lib/api-mappers.ts`
+  - `src/modules/post/hooks/{useCastPosts,useLike,useComments,useTimeline}.ts`
+  - `src/app/api/cast/*` / `src/app/api/guest/*` / `src/app/api/feed/*`
+  - `src/lib/grpc.ts`（`postClient` / `likeClient` は既に bound。symmetric RPC はそれら client に additive で生えているのでクライアント追記不要）
+- 新規 / 並走名で配置するため命名衝突なし。
+
+### 既存パターン（探索で確定、踏襲する）
+
+- **gRPC client**（`src/lib/grpc.ts`）: `createGrpcTransport({ baseUrl: process.env.MONOLITH_URL || "http://localhost:9001" })` を共有し `createClient(Service, transport)`。`postClient` / `likeClient` は既存 export（symmetric RPC を含む同じ Service 定義から生成）。
+- **BFF route**: `requireAuth(req)`（`Authorization` ヘッダ無しで 401）→ `buildGrpcHeaders(req.headers)`（Bearer + X-Request-ID を透過）→ `client.method(init, { headers })` → proto を view にマップして `NextResponse.json` → `catch` で `isConnectError`/`GrpcCode.NOT_FOUND` 個別処理 + `handleApiError(error, "Ctx")`。
+- **dynamic route param は async**: `{ params }: { params: Promise<{ id: string }> }` → `const { id } = await params;`（Next 16）。
+- **SWR hook**: `"use client"`、`getAuthToken()` でトークン有無を判定し SWR key を条件付き（無ければ `null`）、`fetcher`（`@/lib/swr`）で GET。mutation は `authFetch`（`@/lib/auth/fetch`、`{ method, body }`）→ `mutate`。
+- **cursor pagination hook**: `usePaginatedFetch<T, R>({ apiUrl, mapResponse, getItemId, fetchFn, buildParams? })` を使う（既存 `useCastPosts` と同じ）。
+- **stub フィールド（camelCase、確定）**: `Post{id,authorId,content,media[],createdAt,author?,likesCount,commentsCount,visibility,hashtags[],liked}`、`PostAuthor{accountId,displayName,username,avatarUrl}`、`PostMedia{id,mediaType,url,thumbnailUrl,mediaId}`、`ListPostsRequest{limit,cursor,authorId,filter}` / `ListPostsResponse{posts[],nextCursor,hasMore}`、`SavePostRequest{id,content,media[],visibility,hashtags[]}` / `SavePostResponse{post}`、`GetPostRequest{id}` / `GetPostResponse{post}`、`DeletePostRequest{id}` / `DeletePostResponse{}`、`LikePostRequest{postId}` / `LikePostResponse{likesCount}`、`UnlikePostRequest{postId}` / `UnlikePostResponse{likesCount}`、`GetLikeStatusRequest{postIds[]}` / `GetLikeStatusResponse{liked: map<string,bool>}`。RPC は camelCase（`listPosts` / `getPost` / `savePost` / `deletePost` / `likePost` / `unlikePost` / `getLikeStatus`）。
+
+## File Structure
+
+- Create: `src/modules/post/lib/post-view.ts`（symmetric view 型）
+- Create: `src/modules/post/lib/post-mappers.ts`（proto Post → PostView 変換 + SavePostRequest builder）
+- Modify: `src/modules/post/lib/index.ts`（新 mapper を additive で re-export）
+- Create: `src/app/api/posts/route.ts`（GET list, POST create）
+- Create: `src/app/api/posts/[id]/route.ts`（GET, PUT update, DELETE）
+- Create: `src/app/api/posts/[id]/like/route.ts`（POST like, DELETE unlike）
+- Create: `src/app/api/posts/likes/status/route.ts`（GET batch）
+- Create: `src/modules/post/hooks/usePosts.ts`（cursor pagination list）
+- Create: `src/modules/post/hooks/usePost.ts`（single post）
+- Create: `src/modules/post/hooks/usePostLike.ts`（symmetric like）
+- Modify: `src/modules/post/hooks/index.ts`（新 hook を additive で re-export）
+
+> route 衝突回避: `/api/posts/[id]/like` を子セグメントに置き、`/api/posts/likes/status` は `likes/status` の静的セグメント（`[id]` と別階層）。Next の dynamic vs static の優先順序で衝突しない（静的優先）。
+
+---
+
+## Task 1: 型 + mappers（symmetric）
+
+**Files:** Create `src/modules/post/lib/post-view.ts`, `src/modules/post/lib/post-mappers.ts`; Modify `src/modules/post/lib/index.ts`。
+
+- [ ] **Step 1: `src/modules/post/lib/post-view.ts` を作成**
+
+```ts
+export interface PostAuthorView {
+  accountId: string;
+  displayName: string;
+  username: string;
+  avatarUrl: string;
+}
+
+export interface PostMediaView {
+  id: string;
+  mediaType: "image" | "video";
+  url: string;
+  thumbnailUrl: string;
+  mediaId: string;
+}
+
+export interface PostView {
+  id: string;
+  authorId: string;
+  content: string;
+  media: PostMediaView[];
+  createdAt: string;
+  author: PostAuthorView | null;
+  likesCount: number;
+  commentsCount: number;
+  visibility: "public" | "private";
+  hashtags: string[];
+  liked: boolean;
+}
+
+export interface SavePostMediaInput {
+  mediaType: "image" | "video";
+  mediaId: string;
+}
+
+export interface SavePostPayload {
+  id?: string;
+  content: string;
+  media?: SavePostMediaInput[];
+  visibility?: "public" | "private";
+  hashtags?: string[];
+}
+
+export interface PostsListResult {
+  posts: PostView[];
+  nextCursor: string;
+  hasMore: boolean;
+}
+
+export interface PostLikeStatus {
+  liked: Record<string, boolean>;
+}
+
+export interface PostLikeResult {
+  likesCount: number;
+}
+```
+
+- [ ] **Step 2: `src/modules/post/lib/post-mappers.ts` を作成**
+
+```ts
+import type {
+  Post,
+  PostAuthor,
+  PostMedia,
+} from "@/stub/post/v1/post_service_pb";
+import type {
+  PostAuthorView,
+  PostMediaView,
+  PostView,
+  PostsListResult,
+  SavePostPayload,
+} from "@/modules/post/lib/post-view";
+
+export function mapPostAuthorToView(a: PostAuthor | undefined): PostAuthorView | null {
+  if (!a) return null;
+  return {
+    accountId: a.accountId || "",
+    displayName: a.displayName || "",
+    username: a.username || "",
+    avatarUrl: a.avatarUrl || "",
+  };
+}
+
+export function mapPostMediaToView(m: PostMedia): PostMediaView {
+  const t = (m.mediaType || "image") as "image" | "video";
+  return {
+    id: m.id || "",
+    mediaType: t === "video" ? "video" : "image",
+    url: m.url || "",
+    thumbnailUrl: m.thumbnailUrl || "",
+    mediaId: m.mediaId || "",
+  };
+}
+
+export function mapPostToView(p: Post): PostView {
+  const v = (p.visibility || "public").toLowerCase();
+  return {
+    id: p.id,
+    authorId: p.authorId || "",
+    content: p.content || "",
+    media: (p.media || []).map(mapPostMediaToView),
+    createdAt: p.createdAt || "",
+    author: mapPostAuthorToView(p.author),
+    likesCount: p.likesCount || 0,
+    commentsCount: p.commentsCount || 0,
+    visibility: v === "private" ? "private" : "public",
+    hashtags: p.hashtags || [],
+    liked: p.liked || false,
+  };
+}
+
+export function mapPostsListResponse(res: {
+  posts: Post[];
+  nextCursor: string;
+  hasMore: boolean;
+}): PostsListResult {
+  return {
+    posts: (res.posts || []).map(mapPostToView),
+    nextCursor: res.nextCursor || "",
+    hasMore: res.hasMore || false,
+  };
+}
+
+export function buildSavePostRequest(payload: SavePostPayload) {
+  return {
+    id: payload.id || "",
+    content: payload.content,
+    media: (payload.media || []).map((m) => ({
+      id: "",
+      mediaType: m.mediaType,
+      url: "",
+      thumbnailUrl: "",
+      mediaId: m.mediaId,
+    })),
+    visibility: payload.visibility || "public",
+    hashtags: payload.hashtags || [],
+  };
+}
+```
+
+- [ ] **Step 3: `src/modules/post/lib/index.ts` を additive で更新**
+
+現状の内容:
+
+```ts
+export * from "./mappers";
+```
+
+を以下に置き換え（既存 export はそのまま、symmetric を additive 追加）:
+
+```ts
+export * from "./mappers";
+export * from "./post-view";
+export * from "./post-mappers";
+```
+
+- [ ] **Step 4: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | tail -20`
+Expected: 新規型エラー無し（`mapPostToView` の戻り型が `PostView` と一致、`buildSavePostRequest` の戻りが `SavePostRequest` の init 形と一致）。既存の無関係エラーがあっても触らない（増やさないこと）。
+
+---
+
+## Task 2: BFF route handlers（`/api/posts` namespace 新設）
+
+**Files:** Create 4 route ファイル。
+
+- [ ] **Step 1: `src/app/api/posts/route.ts`（GET list + POST create）**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { postClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import {
+  mapPostToView,
+  mapPostsListResponse,
+  buildSavePostRequest,
+} from "@/modules/post/lib/post-mappers";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const limitParam = req.nextUrl.searchParams.get("limit");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+    const authorId = req.nextUrl.searchParams.get("author_id") || "";
+    const filter = req.nextUrl.searchParams.get("filter") || "";
+
+    const limit = limitParam ? Math.max(1, Math.min(50, parseInt(limitParam, 10) || 20)) : 20;
+    const res = await postClient.listPosts(
+      { limit, cursor, authorId, filter },
+      { headers }
+    );
+    return NextResponse.json(mapPostsListResponse(res));
+  } catch (error: unknown) {
+    return handleApiError(error, "ListPosts");
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const body = (await req.json()) as SavePostPayload;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await postClient.savePost(buildSavePostRequest({ ...body, id: "" }), { headers });
+    if (!res.post) {
+      return NextResponse.json({ error: "保存に失敗しました" }, { status: 500 });
+    }
+    return NextResponse.json({ post: mapPostToView(res.post) });
+  } catch (error: unknown) {
+    return handleApiError(error, "CreatePost");
+  }
+}
+```
+
+- [ ] **Step 2: `src/app/api/posts/[id]/route.ts`（GET + PUT + DELETE）**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { postClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { isConnectError, GrpcCode } from "@/lib/grpc-errors";
+import { mapPostToView, buildSavePostRequest } from "@/modules/post/lib/post-mappers";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await postClient.getPost({ id }, { headers });
+    if (!res.post) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return NextResponse.json({ post: mapPostToView(res.post) });
+  } catch (error: unknown) {
+    if (isConnectError(error) && error.code === GrpcCode.NOT_FOUND) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return handleApiError(error, "GetPost");
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const body = (await req.json()) as SavePostPayload;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await postClient.savePost(buildSavePostRequest({ ...body, id }), { headers });
+    if (!res.post) {
+      return NextResponse.json({ error: "保存に失敗しました" }, { status: 500 });
+    }
+    return NextResponse.json({ post: mapPostToView(res.post) });
+  } catch (error: unknown) {
+    if (isConnectError(error) && error.code === GrpcCode.NOT_FOUND) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return handleApiError(error, "UpdatePost");
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    await postClient.deletePost({ id }, { headers });
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    if (isConnectError(error) && error.code === GrpcCode.NOT_FOUND) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return handleApiError(error, "DeletePost");
+  }
+}
+```
+
+- [ ] **Step 3: `src/app/api/posts/[id]/like/route.ts`（POST like + DELETE unlike）**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { likeClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await likeClient.likePost({ postId: id }, { headers });
+    return NextResponse.json({ likesCount: res.likesCount });
+  } catch (error: unknown) {
+    return handleApiError(error, "LikePost");
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await likeClient.unlikePost({ postId: id }, { headers });
+    return NextResponse.json({ likesCount: res.likesCount });
+  } catch (error: unknown) {
+    return handleApiError(error, "UnlikePost");
+  }
+}
+```
+
+- [ ] **Step 4: `src/app/api/posts/likes/status/route.ts`（GET batch）**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { likeClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const raw = req.nextUrl.searchParams.get("post_ids") || "";
+    const postIds = raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+    if (postIds.length === 0) {
+      return NextResponse.json({ liked: {} });
+    }
+    const res = await likeClient.getLikeStatus({ postIds }, { headers });
+    const liked: Record<string, boolean> = {};
+    for (const [k, v] of Object.entries(res.liked || {})) {
+      liked[k] = Boolean(v);
+    }
+    return NextResponse.json({ liked });
+  } catch (error: unknown) {
+    return handleApiError(error, "GetLikeStatus");
+  }
+}
+```
+
+- [ ] **Step 5: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | tail -20`
+Expected: 新規 route の型エラーなし。`postClient.listPosts` / `getPost` / `savePost` / `deletePost`、`likeClient.likePost` / `unlikePost` / `getLikeStatus` の init 形と一致、`params` の Promise が型に合う。
+
+---
+
+## Task 3: SWR / pagination hooks
+
+**Files:** Create `src/modules/post/hooks/{usePosts,usePost,usePostLike}.ts`; Modify `src/modules/post/hooks/index.ts`。
+
+- [ ] **Step 1: `src/modules/post/hooks/usePosts.ts`（cursor pagination list）**
+
+```ts
+"use client";
+
+import { useCallback } from "react";
+import { authFetch } from "@/lib/auth/fetch";
+import { usePaginatedFetch, type PaginatedResult } from "@/lib/hooks/usePaginatedFetch";
+import type { PostView, PostsListResult, SavePostPayload } from "@/modules/post/lib/post-view";
+
+interface UsePostsOptions {
+  authorId?: string;
+  filter?: string;
+}
+
+interface SavePostResponse {
+  post: PostView;
+}
+
+export function usePosts(options: UsePostsOptions = {}) {
+  const { authorId, filter } = options;
+
+  const mapResponse = useCallback(
+    (data: PostsListResult): PaginatedResult<PostView> => ({
+      items: data.posts,
+      hasMore: data.hasMore,
+      nextCursor: data.nextCursor || null,
+    }),
+    []
+  );
+
+  const getItemId = useCallback((p: PostView) => p.id, []);
+
+  const fetchFn = useCallback(
+    async (url: string): Promise<PostsListResult> =>
+      authFetch<PostsListResult>(url, { cache: "no-store" }),
+    []
+  );
+
+  const buildParams = useCallback(
+    (params: URLSearchParams) => {
+      if (authorId) params.set("author_id", authorId);
+      if (filter) params.set("filter", filter);
+    },
+    [authorId, filter]
+  );
+
+  const {
+    items: posts,
+    setItems: setPosts,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    initialized,
+    fetchInitial,
+    fetchMore,
+    reset,
+  } = usePaginatedFetch<PostView, PostsListResult>({
+    apiUrl: "/api/posts",
+    mapResponse,
+    getItemId,
+    fetchFn,
+    buildParams,
+  });
+
+  const createPost = useCallback(
+    async (payload: SavePostPayload) => {
+      const data = await authFetch<SavePostResponse>("/api/posts", {
+        method: "POST",
+        body: payload,
+      });
+      setPosts((prev) => [data.post, ...prev]);
+      return data.post;
+    },
+    [setPosts]
+  );
+
+  const updatePost = useCallback(
+    async (id: string, payload: SavePostPayload) => {
+      const data = await authFetch<SavePostResponse>(`/api/posts/${encodeURIComponent(id)}`, {
+        method: "PUT",
+        body: payload,
+      });
+      setPosts((prev) => prev.map((p) => (p.id === data.post.id ? data.post : p)));
+      return data.post;
+    },
+    [setPosts]
+  );
+
+  const deletePost = useCallback(
+    async (id: string) => {
+      await authFetch(`/api/posts/${encodeURIComponent(id)}`, { method: "DELETE" });
+      setPosts((prev) => prev.filter((p) => p.id !== id));
+    },
+    [setPosts]
+  );
+
+  return {
+    posts,
+    setPosts,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    initialized,
+    fetchInitial,
+    fetchMore,
+    reset,
+    createPost,
+    updatePost,
+    deletePost,
+  };
+}
+```
+
+- [ ] **Step 2: `src/modules/post/hooks/usePost.ts`（single post）**
+
+```ts
+"use client";
+
+import useSWR from "swr";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PostView } from "@/modules/post/lib/post-view";
+
+interface PostResponse {
+  post: PostView;
+}
+
+export function usePost(id: string | null) {
+  const token = getAuthToken();
+  const { data, error, isLoading, mutate } = useSWR<PostResponse>(
+    token && id ? `/api/posts/${encodeURIComponent(id)}` : null,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    post: data?.post ?? null,
+    loading: isLoading,
+    error,
+    mutate,
+  };
+}
+```
+
+- [ ] **Step 3: `src/modules/post/hooks/usePostLike.ts`（symmetric like）**
+
+```ts
+"use client";
+
+import { useCallback, useState } from "react";
+import { authFetch } from "@/lib/auth/fetch";
+import { getAuthToken } from "@/lib/swr";
+
+interface LikeEntry {
+  liked: boolean;
+  likesCount: number;
+}
+
+interface LikeResponse {
+  likesCount: number;
+}
+
+interface LikeStatusResponse {
+  liked: Record<string, boolean>;
+}
+
+export function usePostLike() {
+  const [state, setState] = useState<Record<string, LikeEntry>>({});
+  const [loading, setLoading] = useState(false);
+
+  const like = useCallback(async (postId: string) => {
+    if (!getAuthToken()) {
+      // FALLBACK: Returns null when not authenticated
+      console.warn("Cannot like: not authenticated");
+      return null;
+    }
+    setLoading(true);
+    try {
+      const data = await authFetch<LikeResponse>(
+        `/api/posts/${encodeURIComponent(postId)}/like`,
+        { method: "POST" }
+      );
+      setState((prev) => ({
+        ...prev,
+        [postId]: { liked: true, likesCount: data.likesCount },
+      }));
+      return data.likesCount;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const unlike = useCallback(async (postId: string) => {
+    if (!getAuthToken()) {
+      // FALLBACK: Returns null when not authenticated
+      console.warn("Cannot unlike: not authenticated");
+      return null;
+    }
+    setLoading(true);
+    try {
+      const data = await authFetch<LikeResponse>(
+        `/api/posts/${encodeURIComponent(postId)}/like`,
+        { method: "DELETE" }
+      );
+      setState((prev) => ({
+        ...prev,
+        [postId]: { liked: false, likesCount: data.likesCount },
+      }));
+      return data.likesCount;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const toggleLike = useCallback(
+    async (postId: string, currentlyLiked: boolean) =>
+      currentlyLiked ? unlike(postId) : like(postId),
+    [like, unlike]
+  );
+
+  const fetchLikeStatus = useCallback(
+    async (postIds: string[]): Promise<Record<string, boolean>> => {
+      if (postIds.length === 0) return {};
+      const data = await authFetch<LikeStatusResponse>(
+        `/api/posts/likes/status?post_ids=${encodeURIComponent(postIds.join(","))}`,
+        { method: "GET" }
+      );
+      return data.liked || {};
+    },
+    []
+  );
+
+  const setInitialState = useCallback(
+    (postId: string, liked: boolean, likesCount: number) => {
+      setState((prev) => ({
+        ...prev,
+        [postId]: { liked, likesCount },
+      }));
+    },
+    []
+  );
+
+  const isLiked = useCallback(
+    (postId: string, fallback = false) => state[postId]?.liked ?? fallback,
+    [state]
+  );
+  const getLikesCount = useCallback(
+    (postId: string, fallback = 0) => state[postId]?.likesCount ?? fallback,
+    [state]
+  );
+
+  return {
+    like,
+    unlike,
+    toggleLike,
+    fetchLikeStatus,
+    setInitialState,
+    isLiked,
+    getLikesCount,
+    state,
+    loading,
+  };
+}
+```
+
+- [ ] **Step 4: `src/modules/post/hooks/index.ts` を additive で更新**
+
+現状の内容:
+
+```ts
+export { useCastPosts } from "./useCastPosts";
+export { useLike } from "./useLike";
+export { useComments } from "./useComments";
+export { useTimeline, useGuestPost } from "./useTimeline";
+```
+
+を以下に置き換え（既存 export は保持、symmetric を additive 追加）:
+
+```ts
+export { useCastPosts } from "./useCastPosts";
+export { useLike } from "./useLike";
+export { useComments } from "./useComments";
+export { useTimeline, useGuestPost } from "./useTimeline";
+export { usePosts } from "./usePosts";
+export { usePost } from "./usePost";
+export { usePostLike } from "./usePostLike";
+```
+
+- [ ] **Step 5: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | tail -20`
+Expected: 新規 hooks の型エラーなし。`usePaginatedFetch<PostView, PostsListResult>` の generics が `mapResponse` / `getItemId` / `fetchFn` の型と整合。
+
+---
+
+## Task 4: build / lint で検証してコミット
+
+**Files:** なし（検証 + コミット）。
+
+- [ ] **Step 1: 本番ビルド（型 + バンドル）**
+
+Run: `cd services/frontend/workspace && pnpm build 2>&1 | tail -30`
+Expected: 成功。新 route（`/api/posts`, `/api/posts/[id]`, `/api/posts/[id]/like`, `/api/posts/likes/status`）がビルド出力に現れ、型エラーなし。`/api/cast/timeline` 等の旧 route も保持されていること。
+
+- [ ] **Step 2: lint**
+
+Run: `cd services/frontend/workspace && pnpm lint 2>&1 | tail -20`
+Expected: 新規ファイルに lint エラーなし。
+
+- [ ] **Step 3: コミット（signoff、Co-Authored-By 無し）**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-posts-frontend
+git add services/frontend/workspace/src/modules/post services/frontend/workspace/src/app/api/posts docs/superpowers/plans/2026-06-08-posts-q4a-frontend-data-layer.md
+git commit -s -m "feat(posts): add symmetric posts frontend data layer (BFF + hooks)"
+```
+（push は親が判断、ここでは push しない。）
+
+---
+
+## Deferred（Q4a では実施しない）
+
+- **PostCardBinding**（`PostView` → 既存 `ui/post-card.tsx` `PostCardProps` への adapter）→ **Q4b**。
+- **PostComposer**（投稿作成 form、`SavePostPayload` 構築 + `createPost` 呼び出し）→ **Q4b**。
+- **`/posts/[id]` 投稿詳細ページ**（本文 + media + like ボタン + コメント表示）→ **Q4b**。
+- **`/dev/ui` への mock デモ**（symmetric post の視覚確認セクション追加）→ **Q4b**。
+- **comments の symmetric 化**（現状 `user_id` ベースで対称的、BFF は cast/guest 旧パス → cleanup フェーズで ProfileService 化と同時に行う）。
+- **feed timeline**（複数著者の集約タイムライン）→ feed スライス。
+- **follow-gate**（鍵アカ閲覧制限）→ social スライス。
+- **media 実アップロード e2e**（object storage 未配備のため、Q4b でも mock URL 表示までに留める）。
+- **旧 `useCastPosts` / `useLike` / `useTimeline` / `/api/cast/timeline` の撤去**（feed / dev が消費中 → cleanup フェーズで一括）。
+
+## Self-Review（作成者チェック済）
+
+- **Spec coverage（Q4a 範囲）**: §API contract の symmetric PostService 4 RPC + LikeService 3 RPC を BFF + hooks で配線。§Frontend の「型 + mappers + SWR hooks + BFF routes」をデータ層として完全実装。UI は明示的に Q4b へ分離。
+- **Additive で build-green**: 旧 `useCastPosts` / `useLike` / `useTimeline` / `useComments` と `types.ts` / `mappers.ts` / `api-mappers.ts` は無改変。`hooks/index.ts` と `lib/index.ts` は既存 export を保持し additive で追加。`src/lib/grpc.ts` は無改変（`postClient` / `likeClient` 既存）。`/api/cast/*` / `/api/guest/*` も無改変、新 `/api/posts` namespace で独立配置。
+- **Placeholder 無し**: 型 / mappers / 4 route / 3 hooks すべて完全コード。
+- **型 / 命名整合**:
+  - `PostView` ↔ proto `Post`（camelCase: `authorId`, `likesCount`, `commentsCount`, `liked`）対応。
+  - `PostMediaView.mediaType` は `"image" | "video"` リテラル union、`mapPostMediaToView` で proto の `string` を絞り込み。
+  - `SavePostPayload` → `buildSavePostRequest` 戻り = `SavePostRequest` の init 形（`id` / `content` / `media[]` / `visibility` / `hashtags[]`）と一致。`PostMedia` init には `id` / `url` / `thumbnailUrl` も必要（input 時は空文字、`mediaId` のみが実値）。
+  - BFF が返す `{ post: PostView }` / `{ posts, nextCursor, hasMore }` / `{ likesCount }` / `{ liked }` を hooks の response interface と一致させた。
+  - `usePosts` の `usePaginatedFetch<PostView, PostsListResult>` generics 整合。
+  - dynamic params は `Promise<{id}>`（Next 16 規約）。
+  - `/api/posts/likes/status` を `[id]` と別階層に置き route 衝突回避（静的セグメント `likes/status`）。
+- **テスト方針**: frontend ランナー無し → `pnpm build`（tsc 型チェック）+ `pnpm lint` を検証本体に。ユニットテストランナーは未依頼のため追加せず（mapper は純関数で型が主担保、ローカル e2e は Q4b で `/dev/ui` + `[[local-e2e-run]]` メモリ手順で実施）。

--- a/docs/superpowers/plans/2026-06-08-posts-q4b-frontend-ui.md
+++ b/docs/superpowers/plans/2026-06-08-posts-q4b-frontend-ui.md
@@ -1,0 +1,471 @@
+# Posts Q4b: frontend UI (PostCardBinding + PostComposer + 投稿詳細 + /dev/ui demo) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** symmetric Post の **UI 層**を構築する: `PostView` ↔ 既存 `ui/post-card.tsx` の adapter (`PostCardBinding`)、投稿作成フォーム (`PostComposer`)、投稿詳細ページ (`/posts/[id]`)、`/dev/ui` への mock デモセクション追加。Q4a で配線した data 層 (hooks / BFF) を消費し、ブラウザ実機で視覚確認できる状態にする。
+
+**Architecture:** **Additive、build-green**。Q4a の `usePosts` / `usePost` / `usePostLike` と `PostView` 型を消費。コメントは現状 `useComments` (旧 `/api/guest/comments` ベース、内部的に user_id 対称) を継続使用するが、**Q4b では comment 一覧描画はせず comment 件数表示のみ** (comments の UI rework は cleanup フェーズで ProfileService 化と同時に行う)。media 実アップロードは object storage 未配備なので **未対応**。投稿詳細はテキスト・media (サムネ表示)・like・コメント件数のみ。`PostCardBinding` は `usePostLike` を内部で持ち like toggle 完結。`PostComposer` は `onSubmit` prop を取り fetch は親 (= `usePosts.createPost`) に任せる純フォーム。
+
+**Tech Stack:** Next.js 16 / React 19 / TypeScript / Tailwind / pnpm。既存 ui primitive (`ui/post-card`, `ui/button`, `ui/textarea`, `ui/avatar`) を再利用。
+
+**Spec:** `docs/superpowers/specs/2026-06-07-posts-slice-design.md`（§Frontend）。前提: Q4a 完了 (PR #653、`src/modules/post/lib/{post-view,post-mappers}.ts` + 4 BFF route + 3 hook が main base に存在)。
+
+---
+
+## Context for the implementer
+
+- worktree（ここの中だけ編集）: `/Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-posts-frontend`。frontend app root: `services/frontend/workspace`。branch `feat/posts-frontend`（Q4a が既に 2 commit 乗っており、Q4b は **同じ branch に additive 追加**）。**push しない・PR は同じ #653 が更新されるだけなので handle 不要**。
+- 検索は **`/usr/bin/grep`** / `/usr/bin/find`。import alias `@/` → `src/`。
+- **テストランナーは無い**。検証は `pnpm exec tsc --noEmit` (緑必須) + `pnpm build` (緑必須)。`pnpm lint` は環境問題でスキップ。
+- ブラウザ実機検証 (= `pnpm dev` + headless chrome / 手動目視) は plan の最終 task でガイダンスのみ提供、実行は controller (親) が判断。
+- **build-green / additive**: 以下は**触らない**:
+  - Q4a で作成した `src/modules/post/lib/post-view.ts` / `post-mappers.ts` / `app/api/posts/**` / `hooks/{usePosts,usePost,usePostLike}.ts`（修正したい点があれば controller に escalate）
+  - `src/modules/post/types.ts` / `lib/mappers.ts` / `lib/api-mappers.ts` / `hooks/{useCastPosts,useLike,useComments,useTimeline}.ts`（旧、cleanup フェーズで撤去）
+  - `src/components/ui/post-card.tsx` / `ui/button.tsx` / `ui/textarea.tsx` / `ui/avatar.tsx` 等の primitive (presentational なので拡張は次のスライス)
+  - `src/lib/grpc.ts` 等の core lib
+- `hooks/index.ts` と `lib/index.ts` は Q4a で更新済。Q4b では components が新規 namespace `src/modules/post/components/` に来るので、ルート `index.ts` (`export * from "./types"; export * from "./hooks"; export * from "./lib";`) には触らない（components は直接 import）。
+
+### 既存パターン（profile P5c で確立、踏襲する）
+
+- **module components 配置**: `src/modules/profile/components/{ProfileHeader,EditProfileModal,...}.tsx` と同じく `src/modules/post/components/` を新設。
+- **dynamic page**: `src/app/u/[username]/page.tsx` がリファレンス。`"use client"` + `useParams<{...}>` + hook + loading/error early return。
+- **PostCard primitive のシグネチャ** (`src/components/ui/post-card.tsx`):
+  ```ts
+  interface PostCardProps {
+    author: { name: string; handle: string; avatarSrc?: string };
+    time: string;
+    body: string;
+    images?: string[];
+    reactions?: React.ReactNode;
+    className?: string;
+  }
+  ```
+  reactions は ReactNode slot で、PostCardBinding 側で like / コメント件数 / 詳細リンクを差し込む。
+
+- **date helper**: `import { formatTimeAgo } from "@/lib/utils/date";` で `"2024-01-01T12:00:00Z" → "2d ago"`。
+
+- **PostView の型** (Q4a):
+  ```ts
+  interface PostView {
+    id, authorId, content, media: PostMediaView[], createdAt,
+    author: PostAuthorView | null,  // { accountId, displayName, username, avatarUrl }
+    likesCount, commentsCount, visibility: "public"|"private", hashtags[], liked
+  }
+  interface PostMediaView { id, mediaType: "image"|"video", url, thumbnailUrl, mediaId }
+  interface SavePostPayload { id?, content, media?: {mediaType, mediaId}[], visibility?, hashtags? }
+  ```
+
+## File Structure
+
+- Create: `src/modules/post/components/PostCardBinding.tsx`（`PostView` → `PostCard` adapter + like toggle）
+- Create: `src/modules/post/components/PostComposer.tsx`（投稿作成フォーム、`SavePostPayload` を `onSubmit` に渡す純コンポーネント）
+- Create: `src/app/posts/[id]/page.tsx`（投稿詳細ページ）
+- Modify: `src/app/dev/ui/page.tsx`（mock データで `PostCardBinding` / `PostComposer` のセクションを末尾 additive 追加）
+
+> 投稿一覧ページ (`/posts` のような index) は **作らない** — 一覧 = feed スライスの責務 (`feed timeline`)。Q4b は単体投稿 + コンポーズ + デモ視覚確認まで。
+
+---
+
+## Task 1: PostCardBinding（PostView → PostCard adapter + like toggle）
+
+**Files:** Create `src/modules/post/components/PostCardBinding.tsx`。
+
+- [ ] **Step 1: 実装**
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { PostCard } from "@/components/ui/post-card";
+import { formatTimeAgo } from "@/lib/utils/date";
+import type { PostView } from "@/modules/post/lib/post-view";
+import { usePostLike } from "@/modules/post/hooks/usePostLike";
+
+export interface PostCardBindingProps {
+  post: PostView;
+  /** Whether to wrap the body / time area with a link to the post detail page. */
+  detailHref?: string;
+  className?: string;
+}
+
+export function PostCardBinding({ post, detailHref, className }: PostCardBindingProps) {
+  const { isLiked, getLikesCount, toggleLike, setInitialState, loading } = usePostLike();
+
+  useEffect(() => {
+    setInitialState(post.id, post.liked, post.likesCount);
+  }, [post.id, post.liked, post.likesCount, setInitialState]);
+
+  const liked = isLiked(post.id, post.liked);
+  const likesCount = getLikesCount(post.id, post.likesCount);
+
+  const authorName = post.author?.displayName || "名無し";
+  const authorHandle = post.author?.username || post.authorId.slice(0, 8);
+  const avatarSrc = post.author?.avatarUrl || undefined;
+
+  const images = post.media
+    .filter((m) => m.mediaType === "image")
+    .map((m) => m.thumbnailUrl || m.url)
+    .filter((u) => u.length > 0);
+
+  const handleLikeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleLike(post.id, liked).catch(() => {});
+  };
+
+  const reactions = (
+    <>
+      <button
+        type="button"
+        onClick={handleLikeClick}
+        disabled={loading}
+        className="flex items-center gap-1 hover:text-text-primary disabled:opacity-50"
+        aria-pressed={liked}
+        aria-label={liked ? "いいねを解除" : "いいね"}
+      >
+        <span aria-hidden="true">{liked ? "♥" : "♡"}</span>
+        <span>{likesCount}</span>
+      </button>
+      <Link
+        href={detailHref || `/posts/${encodeURIComponent(post.id)}`}
+        className="flex items-center gap-1 hover:text-text-primary"
+        aria-label="コメント"
+      >
+        <span aria-hidden="true">💬</span>
+        <span>{post.commentsCount}</span>
+      </Link>
+      {post.visibility === "private" && (
+        <span className="text-text-muted" aria-label="非公開">🔒</span>
+      )}
+    </>
+  );
+
+  return (
+    <PostCard
+      author={{ name: authorName, handle: authorHandle, avatarSrc }}
+      time={post.createdAt ? formatTimeAgo(post.createdAt) : ""}
+      body={post.content}
+      images={images.length > 0 ? images : undefined}
+      reactions={reactions}
+      className={className}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | /usr/bin/tail -20`
+Expected: 緑（`PostCardProps` の `reactions: React.ReactNode` に Fragment を渡せる、`usePostLike` の戻り型と整合）。
+
+---
+
+## Task 2: PostComposer（投稿作成フォーム）
+
+**Files:** Create `src/modules/post/components/PostComposer.tsx`。
+
+- [ ] **Step 1: 実装**
+
+```tsx
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Toggle } from "@/components/ui/toggle";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+export interface PostComposerProps {
+  /** Called on submit with the form payload. Throws to surface an error to the user. */
+  onSubmit: (payload: SavePostPayload) => Promise<unknown>;
+  /** Optional initial content (for edit reuse later). */
+  initialContent?: string;
+  /** Optional initial visibility. Defaults to "public". */
+  initialVisibility?: "public" | "private";
+  className?: string;
+}
+
+const MAX_LENGTH = 1000;
+
+export function PostComposer({
+  onSubmit,
+  initialContent = "",
+  initialVisibility = "public",
+  className,
+}: PostComposerProps) {
+  const [content, setContent] = useState(initialContent);
+  const [isPrivate, setIsPrivate] = useState(initialVisibility === "private");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = content.trim();
+  const overLimit = content.length > MAX_LENGTH;
+  const canSubmit = !submitting && trimmed.length > 0 && !overLimit;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!canSubmit) return;
+      setSubmitting(true);
+      setError(null);
+      try {
+        await onSubmit({
+          content: trimmed,
+          visibility: isPrivate ? "private" : "public",
+        });
+        setContent("");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "投稿に失敗しました";
+        setError(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [canSubmit, trimmed, isPrivate, onSubmit]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={className}>
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="いまどうしてる？"
+        rows={4}
+        aria-label="投稿内容"
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <label className="flex items-center gap-2 text-sm text-text-secondary">
+          <Toggle checked={isPrivate} onCheckedChange={setIsPrivate} aria-label="非公開投稿" />
+          <span>{isPrivate ? "非公開" : "公開"}</span>
+        </label>
+        <div className="flex items-center gap-3">
+          <span
+            className={`text-xs ${overLimit ? "text-error" : "text-text-muted"}`}
+            aria-live="polite"
+          >
+            {content.length}/{MAX_LENGTH}
+          </span>
+          <Button type="submit" variant="primary" disabled={!canSubmit}>
+            {submitting ? "投稿中…" : "投稿する"}
+          </Button>
+        </div>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm text-error" role="alert">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}
+```
+
+- [ ] **Step 2: Toggle の API 確認**
+
+`src/components/ui/toggle.tsx` を Read で開いて `pressed` / `onPressedChange` のシグネチャを確認。違っていれば PostComposer の props 名を実装側に合わせる（`checked` / `onCheckedChange` 等）。**実装に合わせて plan の方を直す**（既存 primitive は無改変）。
+
+- [ ] **Step 3: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | /usr/bin/tail -20`
+Expected: 緑。
+
+---
+
+## Task 3: 投稿詳細ページ `/posts/[id]`
+
+**Files:** Create `src/app/posts/[id]/page.tsx`。
+
+- [ ] **Step 1: 実装**
+
+```tsx
+"use client";
+
+import { useParams } from "next/navigation";
+import { usePost } from "@/modules/post/hooks/usePost";
+import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+
+export default function PostDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = typeof params.id === "string" ? params.id : "";
+  const { post, loading, error } = usePost(id || null);
+
+  if (loading) {
+    return <main className="mx-auto max-w-xl p-6 text-text-secondary">読み込み中…</main>;
+  }
+  if (error || !post) {
+    return <main className="mx-auto max-w-xl p-6 text-text-secondary">投稿が見つかりませんでした。</main>;
+  }
+
+  return (
+    <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
+      <PostCardBinding post={post} />
+      <p className="px-4 py-6 text-sm text-text-muted">
+        コメント（{post.commentsCount} 件）の表示はコメントスライス UI 更新後に対応。
+      </p>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | /usr/bin/tail -20`
+Expected: 緑。`/posts/[id]` route が Next の dynamic page として認識される。
+
+---
+
+## Task 4: `/dev/ui` mock セクション additive 追加
+
+**Files:** Modify `src/app/dev/ui/page.tsx`。
+
+- [ ] **Step 1: 既存内容を Read**
+
+Run: `cd services/frontend/workspace && /usr/bin/cat src/app/dev/ui/page.tsx | /usr/bin/wc -l`
+内容を Read で確認（`return ( <main>...</main> )` で終わる構造、`PostCard` import 済み）。
+
+- [ ] **Step 2: imports と mock データを additive 追加**
+
+ファイル冒頭の import 群末尾（`import type { ProfileView, AreaView } from "@/modules/profile/types";` の下）に追加:
+
+```tsx
+import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+import { PostComposer } from "@/modules/post/components/PostComposer";
+import type { PostView } from "@/modules/post/lib/post-view";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+```
+
+`mockProfile` 定義の下に追加:
+
+```tsx
+  const mockPosts: PostView[] = [
+    {
+      id: "mock-1",
+      authorId: "demo",
+      content: "新作のお洋服届きました！今日はこれで出勤します🌷",
+      media: [],
+      createdAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      author: {
+        accountId: "demo",
+        displayName: "ゆな",
+        username: "yuna",
+        avatarUrl: "",
+      },
+      likesCount: 12,
+      commentsCount: 3,
+      visibility: "public",
+      hashtags: ["新作", "渋谷"],
+      liked: false,
+    },
+    {
+      id: "mock-2",
+      authorId: "guest-1",
+      content: "今度の週末空いてる方いますか？",
+      media: [],
+      createdAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      author: {
+        accountId: "guest-1",
+        displayName: "ぱにっく",
+        username: "panicboat",
+        avatarUrl: "",
+      },
+      likesCount: 1,
+      commentsCount: 0,
+      visibility: "private",
+      hashtags: [],
+      liked: true,
+    },
+  ];
+
+  const handleMockSubmit = async (payload: SavePostPayload) => {
+    console.log("[dev/ui] mock submit:", payload);
+  };
+```
+
+`new Date(Date.now() - ...)` は dev/ui 内ローカル変数で hydration mismatch 注意。SSR で確定値が欲しければ ISO 固定文字列に置き換えても OK（mock なのでどちらでも視覚確認可）。**確実に問題を避けるなら hardcode** に直す:
+
+```tsx
+      createdAt: "2026-06-08T11:55:00Z",
+      ...
+      createdAt: "2026-06-08T11:00:00Z",
+```
+
+実装ではこの hardcode 版を採用すること（`Date.now()` を component render に入れない方が dev 視覚確認が安定）。
+
+- [ ] **Step 3: section を `<main>` 末尾の `</main>` の直前に additive 追加**
+
+```tsx
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-bold text-text-secondary">PostComposer</h2>
+        <PostComposer onSubmit={handleMockSubmit} />
+      </section>
+
+      <section className="flex flex-col">
+        <h2 className="px-4 pb-3 text-sm font-bold text-text-secondary">PostCardBinding</h2>
+        {mockPosts.map((p) => (
+          <PostCardBinding key={p.id} post={p} />
+        ))}
+      </section>
+```
+
+- [ ] **Step 4: 型チェック**
+
+Run: `cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | /usr/bin/tail -20`
+Expected: 緑。
+
+---
+
+## Task 5: build / dev サーバ案内 / commit
+
+**Files:** なし（検証 + コミット）。
+
+- [ ] **Step 1: 本番ビルド**
+
+Run: `cd services/frontend/workspace && pnpm build 2>&1 | /usr/bin/tail -30`
+Expected: 成功。新 page `/posts/[id]` がビルド出力に dynamic page として登場。`/dev/ui` も継続出力。
+
+- [ ] **Step 2: dev サーバ起動方法（controller 用ガイダンス、subagent は実行しない）**
+
+```bash
+# (controller が判断して起動)
+cd services/frontend/workspace && pnpm dev
+# ブラウザで http://localhost:3000/dev/ui を開き、PostComposer と PostCardBinding mock を視覚確認
+# 投稿詳細の e2e は monolith gRPC + JWT 注入が必要。手順は memory [[local-e2e-run]]
+```
+
+subagent は本ステップ実行不要（コマンドガイダンスのみ）。
+
+- [ ] **Step 3: コミット（signoff、Co-Authored-By 無し）**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-posts-frontend
+/usr/bin/git add services/frontend/workspace/src/modules/post/components services/frontend/workspace/src/app/posts services/frontend/workspace/src/app/dev/ui/page.tsx docs/superpowers/plans/2026-06-08-posts-q4b-frontend-ui.md
+/usr/bin/git commit -s -m "feat(posts): add symmetric posts frontend UI (PostCardBinding + Composer + detail page)"
+```
+（push は親が判断、ここでは push しない。）
+
+---
+
+## Deferred（Q4b では実施しない）
+
+- **コメント一覧描画**（`useComments` 連携、threaded reply）→ comments の symmetric 化と同時に cleanup フェーズで実施。Q4b は comment 件数表示のみ。
+- **media 実アップロード**（`PostComposer` の画像添付ボタン）→ object storage 配備後。
+- **投稿編集 UI**（既存投稿の `usePosts.updatePost` 利用）→ profile 編集と同じく EditPostModal を将来追加。
+- **投稿削除確認 UI**（`usePosts.deletePost` への confirm dialog）→ 同上。
+- **/posts index page**（全投稿一覧）→ feed スライスの timeline 責務。
+- **author 名 link**（PostCardBinding の `@username` を `/u/[username]` 公開プロフィールへ）→ 軽い改善だが author に username が空のケースの fallback 戦略を要詰め、別 PR で。
+- **Edge case 視覚確認**（media 4 枚以上 / video / hashtag 描画）→ Q4b スコープでは hardcode mock 2 件のみ。
+
+## Self-Review（作成者チェック済）
+
+- **Spec coverage（Q4b 範囲）**: §Frontend の「投稿コンポーズ / 投稿詳細 `/posts/[id]` / `PostCard` 活用 / like」を全て実装。**comments は件数表示のみ**で明示的に出して deferred セクションに記録（spec の「コメント機能は表示できる程度」要件と整合、UI rework は cleanup と並走）。
+- **Additive で build-green**: Q4a が触ったファイル群と既存 primitive・旧 hooks に変更無し。新規 component と新規 page のみ追加。`/dev/ui` だけ additive 追記（既存 mock セクションは保持）。
+- **Placeholder 無し**: 全 component / page / mock の完全コード提示。
+- **型 / 命名整合**:
+  - `PostCardBinding` の `usePostLike` 利用は Q4a の hook 戻り値型 (`isLiked(id, fallback)` / `getLikesCount(id, fallback)` / `toggleLike(id, currentlyLiked)` / `setInitialState(id, liked, count)`) と完全一致。
+  - `PostComposer.onSubmit` は `SavePostPayload` を受け、`usePosts.createPost(payload)` シグネチャと型整合。
+  - `PostCard` の `reactions: React.ReactNode` slot に Fragment を渡せる前提（型上 OK）。
+  - dynamic params は `useParams<{id: string}>` で取得（client component で `params: Promise<{...}>` async 規約は server component 用、`useParams` は同期 hook）。`/u/[username]/page.tsx` のリファレンスパターンと一致。
+  - `Toggle` の props 名は実装ファイル確認後、必要なら plan を書き換えて合わせる（既存 primitive 改変禁止）。
+- **テスト方針**: frontend ランナー無し → `pnpm build` で型担保。視覚確認は `/dev/ui` の mock セクションで monolith 起動不要に確認可能。完全 e2e はメモリ [[local-e2e-run]] 手順で controller が実施判断。
+- **dev/ui hydration 対策**: `Date.now()` を render 中に呼ばず、固定 ISO 文字列を使うよう Step 2 で明示。

--- a/services/frontend/workspace/src/app/api/posts/[id]/like/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/[id]/like/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { likeClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await likeClient.likePost({ postId: id }, { headers });
+    return NextResponse.json({ likesCount: res.likesCount });
+  } catch (error: unknown) {
+    return handleApiError(error, "LikePost");
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await likeClient.unlikePost({ postId: id }, { headers });
+    return NextResponse.json({ likesCount: res.likesCount });
+  } catch (error: unknown) {
+    return handleApiError(error, "UnlikePost");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/[id]/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { postClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { isConnectError, GrpcCode } from "@/lib/grpc-errors";
+import { mapPostToView, buildSavePostRequest } from "@/modules/post/lib/post-mappers";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await postClient.getPost({ id }, { headers });
+    if (!res.post) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return NextResponse.json({ post: mapPostToView(res.post) });
+  } catch (error: unknown) {
+    if (isConnectError(error) && error.code === GrpcCode.NOT_FOUND) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return handleApiError(error, "GetPost");
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const body = (await req.json()) as SavePostPayload;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await postClient.savePost(buildSavePostRequest({ ...body, id }), { headers });
+    if (!res.post) {
+      return NextResponse.json({ error: "保存に失敗しました" }, { status: 500 });
+    }
+    return NextResponse.json({ post: mapPostToView(res.post) });
+  } catch (error: unknown) {
+    if (isConnectError(error) && error.code === GrpcCode.NOT_FOUND) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return handleApiError(error, "UpdatePost");
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    await postClient.deletePost({ id }, { headers });
+    return NextResponse.json({ success: true });
+  } catch (error: unknown) {
+    if (isConnectError(error) && error.code === GrpcCode.NOT_FOUND) {
+      return NextResponse.json({ error: "投稿が見つかりませんでした" }, { status: 404 });
+    }
+    return handleApiError(error, "DeletePost");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/likes/status/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/likes/status/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { likeClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const raw = req.nextUrl.searchParams.get("post_ids") || "";
+    const postIds = raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+    if (postIds.length === 0) {
+      return NextResponse.json({ liked: {} });
+    }
+    const res = await likeClient.getLikeStatus({ postIds }, { headers });
+    const liked: Record<string, boolean> = {};
+    for (const [k, v] of Object.entries(res.liked || {})) {
+      liked[k] = Boolean(v);
+    }
+    return NextResponse.json({ liked });
+  } catch (error: unknown) {
+    return handleApiError(error, "GetLikeStatus");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/likes/status/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/likes/status/route.ts
@@ -15,11 +15,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ liked: {} });
     }
     const res = await likeClient.getLikeStatus({ postIds }, { headers });
-    const liked: Record<string, boolean> = {};
-    for (const [k, v] of Object.entries(res.liked || {})) {
-      liked[k] = Boolean(v);
-    }
-    return NextResponse.json({ liked });
+    return NextResponse.json({ liked: res.liked || {} });
   } catch (error: unknown) {
     return handleApiError(error, "GetLikeStatus");
   }

--- a/services/frontend/workspace/src/app/api/posts/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { postClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import {
+  mapPostToView,
+  mapPostsListResponse,
+  buildSavePostRequest,
+} from "@/modules/post/lib/post-mappers";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const limitParam = req.nextUrl.searchParams.get("limit");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+    const authorId = req.nextUrl.searchParams.get("author_id") || "";
+    const filter = req.nextUrl.searchParams.get("filter") || "";
+
+    const limit = limitParam ? Math.max(1, Math.min(50, parseInt(limitParam, 10) || 20)) : 20;
+    const res = await postClient.listPosts(
+      { limit, cursor, authorId, filter },
+      { headers }
+    );
+    return NextResponse.json(mapPostsListResponse(res));
+  } catch (error: unknown) {
+    return handleApiError(error, "ListPosts");
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const body = (await req.json()) as SavePostPayload;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await postClient.savePost(buildSavePostRequest({ ...body, id: "" }), { headers });
+    if (!res.post) {
+      return NextResponse.json({ error: "保存に失敗しました" }, { status: 500 });
+    }
+    return NextResponse.json({ post: mapPostToView(res.post) });
+  } catch (error: unknown) {
+    return handleApiError(error, "CreatePost");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { postClient } from "@/lib/grpc";
 import { buildGrpcHeaders } from "@/lib/request";
-import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { requireAuth, handleApiError, extractPaginationParams } from "@/lib/api-helpers";
 import {
   mapPostToView,
   mapPostsListResponse,
@@ -15,12 +15,10 @@ export async function GET(req: NextRequest) {
     if (authError) return authError;
 
     const headers = buildGrpcHeaders(req.headers);
-    const limitParam = req.nextUrl.searchParams.get("limit");
-    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+    const { limit, cursor } = extractPaginationParams(req.nextUrl.searchParams);
     const authorId = req.nextUrl.searchParams.get("author_id") || "";
     const filter = req.nextUrl.searchParams.get("filter") || "";
 
-    const limit = limitParam ? Math.max(1, Math.min(50, parseInt(limitParam, 10) || 20)) : 20;
     const res = await postClient.listPosts(
       { limit, cursor, authorId, filter },
       { headers }
@@ -38,7 +36,7 @@ export async function POST(req: NextRequest) {
 
     const body = (await req.json()) as SavePostPayload;
     const headers = buildGrpcHeaders(req.headers);
-    const res = await postClient.savePost(buildSavePostRequest({ ...body, id: "" }), { headers });
+    const res = await postClient.savePost(buildSavePostRequest(body), { headers });
     if (!res.post) {
       return NextResponse.json({ error: "保存に失敗しました" }, { status: 500 });
     }

--- a/services/frontend/workspace/src/app/dev/ui/page.tsx
+++ b/services/frontend/workspace/src/app/dev/ui/page.tsx
@@ -16,6 +16,9 @@ import { EditProfileModal } from "@/modules/profile/components/EditProfileModal"
 import { AreaAccordion } from "@/modules/profile/components/AreaAccordion";
 import { ImageUpload } from "@/modules/profile/components/ImageUpload";
 import type { ProfileView, AreaView } from "@/modules/profile/types";
+import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+import { PostComposer } from "@/modules/post/components/PostComposer";
+import type { PostView, SavePostPayload } from "@/modules/post/lib/post-view";
 
 export default function DevUiPage() {
   const [tab, setTab] = useState("home");
@@ -52,6 +55,49 @@ export default function DevUiPage() {
     industry: "デリヘル",
     areas: [{ id: "a1", region: "関東", prefecture: "東京都", name: "渋谷", code: "shibuya" }],
     shopId: "",
+  };
+
+  const mockPosts: PostView[] = [
+    {
+      id: "mock-1",
+      authorId: "demo",
+      content: "新作のお洋服届きました！今日はこれで出勤します🌷",
+      media: [],
+      createdAt: "2026-06-08T11:55:00Z",
+      author: {
+        accountId: "demo",
+        displayName: "ゆな",
+        username: "yuna",
+        avatarUrl: "",
+      },
+      likesCount: 12,
+      commentsCount: 3,
+      visibility: "public",
+      hashtags: ["新作", "渋谷"],
+      liked: false,
+    },
+    {
+      id: "mock-2",
+      authorId: "guest-1",
+      content: "今度の週末空いてる方いますか？",
+      media: [],
+      createdAt: "2026-06-08T11:00:00Z",
+      author: {
+        accountId: "guest-1",
+        displayName: "ぱにっく",
+        username: "panicboat",
+        avatarUrl: "",
+      },
+      likesCount: 1,
+      commentsCount: 0,
+      visibility: "private",
+      hashtags: [],
+      liked: true,
+    },
+  ];
+
+  const handleMockSubmit = async (payload: SavePostPayload) => {
+    console.log("[dev/ui] mock submit:", payload);
   };
 
   return (
@@ -164,6 +210,18 @@ export default function DevUiPage() {
       <section className="flex flex-col gap-3">
         <ImageUpload shape="cover" onUploaded={() => {}} />
         <ImageUpload shape="avatar" onUploaded={() => {}} />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-bold text-text-secondary">PostComposer</h2>
+        <PostComposer onSubmit={handleMockSubmit} />
+      </section>
+
+      <section className="flex flex-col">
+        <h2 className="px-4 pb-3 text-sm font-bold text-text-secondary">PostCardBinding</h2>
+        {mockPosts.map((p) => (
+          <PostCardBinding key={p.id} post={p} />
+        ))}
       </section>
     </main>
   );

--- a/services/frontend/workspace/src/app/posts/[id]/page.tsx
+++ b/services/frontend/workspace/src/app/posts/[id]/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { usePost } from "@/modules/post/hooks/usePost";
+import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+
+export default function PostDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = typeof params.id === "string" ? params.id : "";
+  const { post, loading, error } = usePost(id || null);
+
+  if (loading) {
+    return <main className="mx-auto max-w-xl p-6 text-text-secondary">読み込み中…</main>;
+  }
+  if (error || !post) {
+    return <main className="mx-auto max-w-xl p-6 text-text-secondary">投稿が見つかりませんでした。</main>;
+  }
+
+  return (
+    <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
+      <PostCardBinding post={post} />
+      <p className="px-4 py-6 text-sm text-text-muted">
+        コメント（{post.commentsCount} 件）の表示はコメントスライス UI 更新後に対応。
+      </p>
+    </main>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/components/PostCardBinding.tsx
+++ b/services/frontend/workspace/src/modules/post/components/PostCardBinding.tsx
@@ -19,7 +19,10 @@ export function PostCardBinding({ post, detailHref, className }: PostCardBinding
 
   useEffect(() => {
     setInitialState(post.id, post.liked, post.likesCount);
-  }, [post.id, post.liked, post.likesCount, setInitialState]);
+    // Intentionally only depend on post.id: re-running on liked/likesCount changes
+    // would clobber the user's most recent like toggle when SWR re-injects a stale snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [post.id]);
 
   const liked = isLiked(post.id, post.liked);
   const likesCount = getLikesCount(post.id, post.likesCount);

--- a/services/frontend/workspace/src/modules/post/components/PostCardBinding.tsx
+++ b/services/frontend/workspace/src/modules/post/components/PostCardBinding.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { PostCard } from "@/components/ui/post-card";
+import { formatTimeAgo } from "@/lib/utils/date";
+import type { PostView } from "@/modules/post/lib/post-view";
+import { usePostLike } from "@/modules/post/hooks/usePostLike";
+
+export interface PostCardBindingProps {
+  post: PostView;
+  /** Whether to wrap the body / time area with a link to the post detail page. */
+  detailHref?: string;
+  className?: string;
+}
+
+export function PostCardBinding({ post, detailHref, className }: PostCardBindingProps) {
+  const { isLiked, getLikesCount, toggleLike, setInitialState, loading } = usePostLike();
+
+  useEffect(() => {
+    setInitialState(post.id, post.liked, post.likesCount);
+  }, [post.id, post.liked, post.likesCount, setInitialState]);
+
+  const liked = isLiked(post.id, post.liked);
+  const likesCount = getLikesCount(post.id, post.likesCount);
+
+  const authorName = post.author?.displayName || "名無し";
+  const authorHandle = post.author?.username || post.authorId.slice(0, 8);
+  const avatarSrc = post.author?.avatarUrl || undefined;
+
+  const images = post.media
+    .filter((m) => m.mediaType === "image")
+    .map((m) => m.thumbnailUrl || m.url)
+    .filter((u) => u.length > 0);
+
+  const handleLikeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleLike(post.id, liked).catch(() => {});
+  };
+
+  const reactions = (
+    <>
+      <button
+        type="button"
+        onClick={handleLikeClick}
+        disabled={loading}
+        className="flex items-center gap-1 hover:text-text-primary disabled:opacity-50"
+        aria-pressed={liked}
+        aria-label={liked ? "いいねを解除" : "いいね"}
+      >
+        <span aria-hidden="true">{liked ? "♥" : "♡"}</span>
+        <span>{likesCount}</span>
+      </button>
+      <Link
+        href={detailHref || `/posts/${encodeURIComponent(post.id)}`}
+        className="flex items-center gap-1 hover:text-text-primary"
+        aria-label="コメント"
+      >
+        <span aria-hidden="true">💬</span>
+        <span>{post.commentsCount}</span>
+      </Link>
+      {post.visibility === "private" && (
+        <span className="text-text-muted" aria-label="非公開">🔒</span>
+      )}
+    </>
+  );
+
+  return (
+    <PostCard
+      author={{ name: authorName, handle: authorHandle, avatarSrc }}
+      time={post.createdAt ? formatTimeAgo(post.createdAt) : ""}
+      body={post.content}
+      images={images.length > 0 ? images : undefined}
+      reactions={reactions}
+      className={className}
+    />
+  );
+}

--- a/services/frontend/workspace/src/modules/post/components/PostComposer.tsx
+++ b/services/frontend/workspace/src/modules/post/components/PostComposer.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Toggle } from "@/components/ui/toggle";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+export interface PostComposerProps {
+  /** Called on submit with the form payload. Throws to surface an error to the user. */
+  onSubmit: (payload: SavePostPayload) => Promise<unknown>;
+  /** Optional initial content (for edit reuse later). */
+  initialContent?: string;
+  /** Optional initial visibility. Defaults to "public". */
+  initialVisibility?: "public" | "private";
+  className?: string;
+}
+
+const MAX_LENGTH = 1000;
+
+export function PostComposer({
+  onSubmit,
+  initialContent = "",
+  initialVisibility = "public",
+  className,
+}: PostComposerProps) {
+  const [content, setContent] = useState(initialContent);
+  const [isPrivate, setIsPrivate] = useState(initialVisibility === "private");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = content.trim();
+  const overLimit = content.length > MAX_LENGTH;
+  const canSubmit = !submitting && trimmed.length > 0 && !overLimit;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!canSubmit) return;
+      setSubmitting(true);
+      setError(null);
+      try {
+        await onSubmit({
+          content: trimmed,
+          visibility: isPrivate ? "private" : "public",
+        });
+        setContent("");
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "投稿に失敗しました";
+        setError(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [canSubmit, trimmed, isPrivate, onSubmit]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={className}>
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="いまどうしてる？"
+        rows={4}
+        aria-label="投稿内容"
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <label className="flex items-center gap-2 text-sm text-text-secondary">
+          <Toggle checked={isPrivate} onCheckedChange={setIsPrivate} aria-label="非公開投稿" />
+          <span>{isPrivate ? "非公開" : "公開"}</span>
+        </label>
+        <div className="flex items-center gap-3">
+          <span
+            className={`text-xs ${overLimit ? "text-error" : "text-text-muted"}`}
+            aria-live="polite"
+          >
+            {content.length}/{MAX_LENGTH}
+          </span>
+          <Button type="submit" variant="primary" disabled={!canSubmit}>
+            {submitting ? "投稿中…" : "投稿する"}
+          </Button>
+        </div>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm text-error" role="alert">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/hooks/index.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/index.ts
@@ -2,3 +2,6 @@ export { useCastPosts } from "./useCastPosts";
 export { useLike } from "./useLike";
 export { useComments } from "./useComments";
 export { useTimeline, useGuestPost } from "./useTimeline";
+export { usePosts } from "./usePosts";
+export { usePost } from "./usePost";
+export { usePostLike } from "./usePostLike";

--- a/services/frontend/workspace/src/modules/post/hooks/usePost.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/usePost.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PostView } from "@/modules/post/lib/post-view";
+
+interface PostResponse {
+  post: PostView;
+}
+
+export function usePost(id: string | null) {
+  const token = getAuthToken();
+  const { data, error, isLoading, mutate } = useSWR<PostResponse>(
+    token && id ? `/api/posts/${encodeURIComponent(id)}` : null,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    post: data?.post ?? null,
+    loading: isLoading,
+    error,
+    mutate,
+  };
+}

--- a/services/frontend/workspace/src/modules/post/hooks/usePostLike.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/usePostLike.ts
@@ -38,6 +38,9 @@ export function usePostLike() {
         [postId]: { liked: true, likesCount: data.likesCount },
       }));
       return data.likesCount;
+    } catch (e) {
+      console.error("Like error:", e);
+      throw e;
     } finally {
       setLoading(false);
     }
@@ -60,6 +63,9 @@ export function usePostLike() {
         [postId]: { liked: false, likesCount: data.likesCount },
       }));
       return data.likesCount;
+    } catch (e) {
+      console.error("Unlike error:", e);
+      throw e;
     } finally {
       setLoading(false);
     }

--- a/services/frontend/workspace/src/modules/post/hooks/usePostLike.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/usePostLike.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { authFetch } from "@/lib/auth/fetch";
+import { getAuthToken } from "@/lib/swr";
+
+interface LikeEntry {
+  liked: boolean;
+  likesCount: number;
+}
+
+interface LikeResponse {
+  likesCount: number;
+}
+
+interface LikeStatusResponse {
+  liked: Record<string, boolean>;
+}
+
+export function usePostLike() {
+  const [state, setState] = useState<Record<string, LikeEntry>>({});
+  const [loading, setLoading] = useState(false);
+
+  const like = useCallback(async (postId: string) => {
+    if (!getAuthToken()) {
+      // FALLBACK: Returns null when not authenticated
+      console.warn("Cannot like: not authenticated");
+      return null;
+    }
+    setLoading(true);
+    try {
+      const data = await authFetch<LikeResponse>(
+        `/api/posts/${encodeURIComponent(postId)}/like`,
+        { method: "POST" }
+      );
+      setState((prev) => ({
+        ...prev,
+        [postId]: { liked: true, likesCount: data.likesCount },
+      }));
+      return data.likesCount;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const unlike = useCallback(async (postId: string) => {
+    if (!getAuthToken()) {
+      // FALLBACK: Returns null when not authenticated
+      console.warn("Cannot unlike: not authenticated");
+      return null;
+    }
+    setLoading(true);
+    try {
+      const data = await authFetch<LikeResponse>(
+        `/api/posts/${encodeURIComponent(postId)}/like`,
+        { method: "DELETE" }
+      );
+      setState((prev) => ({
+        ...prev,
+        [postId]: { liked: false, likesCount: data.likesCount },
+      }));
+      return data.likesCount;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const toggleLike = useCallback(
+    async (postId: string, currentlyLiked: boolean) =>
+      currentlyLiked ? unlike(postId) : like(postId),
+    [like, unlike]
+  );
+
+  const fetchLikeStatus = useCallback(
+    async (postIds: string[]): Promise<Record<string, boolean>> => {
+      if (postIds.length === 0) return {};
+      const data = await authFetch<LikeStatusResponse>(
+        `/api/posts/likes/status?post_ids=${encodeURIComponent(postIds.join(","))}`,
+        { method: "GET" }
+      );
+      return data.liked || {};
+    },
+    []
+  );
+
+  const setInitialState = useCallback(
+    (postId: string, liked: boolean, likesCount: number) => {
+      setState((prev) => ({
+        ...prev,
+        [postId]: { liked, likesCount },
+      }));
+    },
+    []
+  );
+
+  const isLiked = useCallback(
+    (postId: string, fallback = false) => state[postId]?.liked ?? fallback,
+    [state]
+  );
+  const getLikesCount = useCallback(
+    (postId: string, fallback = 0) => state[postId]?.likesCount ?? fallback,
+    [state]
+  );
+
+  return {
+    like,
+    unlike,
+    toggleLike,
+    fetchLikeStatus,
+    setInitialState,
+    isLiked,
+    getLikesCount,
+    state,
+    loading,
+  };
+}

--- a/services/frontend/workspace/src/modules/post/hooks/usePosts.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/usePosts.ts
@@ -21,7 +21,7 @@ export function usePosts(options: UsePostsOptions = {}) {
     (data: PostsListView): PaginatedResult<PostView> => ({
       items: data.posts,
       hasMore: data.hasMore,
-      nextCursor: data.nextCursor || null,
+      nextCursor: data.nextCursor,
     }),
     []
   );

--- a/services/frontend/workspace/src/modules/post/hooks/usePosts.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/usePosts.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback } from "react";
+import { authFetch } from "@/lib/auth/fetch";
+import { usePaginatedFetch, type PaginatedResult } from "@/lib/hooks/usePaginatedFetch";
+import type { PostView, PostsListView, SavePostPayload } from "@/modules/post/lib/post-view";
+
+interface UsePostsOptions {
+  authorId?: string;
+  filter?: string;
+}
+
+interface SavePostResponse {
+  post: PostView;
+}
+
+export function usePosts(options: UsePostsOptions = {}) {
+  const { authorId, filter } = options;
+
+  const mapResponse = useCallback(
+    (data: PostsListView): PaginatedResult<PostView> => ({
+      items: data.posts,
+      hasMore: data.hasMore,
+      nextCursor: data.nextCursor || null,
+    }),
+    []
+  );
+
+  const getItemId = useCallback((p: PostView) => p.id, []);
+
+  const fetchFn = useCallback(
+    async (url: string): Promise<PostsListView> =>
+      authFetch<PostsListView>(url, { cache: "no-store" }),
+    []
+  );
+
+  const buildParams = useCallback(
+    (params: URLSearchParams) => {
+      if (authorId) params.set("author_id", authorId);
+      if (filter) params.set("filter", filter);
+    },
+    [authorId, filter]
+  );
+
+  const {
+    items: posts,
+    setItems: setPosts,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    initialized,
+    fetchInitial,
+    fetchMore,
+    reset,
+  } = usePaginatedFetch<PostView, PostsListView>({
+    apiUrl: "/api/posts",
+    mapResponse,
+    getItemId,
+    fetchFn,
+    buildParams,
+  });
+
+  const createPost = useCallback(
+    async (payload: SavePostPayload) => {
+      const data = await authFetch<SavePostResponse>("/api/posts", {
+        method: "POST",
+        body: payload,
+      });
+      setPosts((prev) => [data.post, ...prev]);
+      return data.post;
+    },
+    [setPosts]
+  );
+
+  const updatePost = useCallback(
+    async (id: string, payload: SavePostPayload) => {
+      const data = await authFetch<SavePostResponse>(`/api/posts/${encodeURIComponent(id)}`, {
+        method: "PUT",
+        body: payload,
+      });
+      setPosts((prev) => prev.map((p) => (p.id === data.post.id ? data.post : p)));
+      return data.post;
+    },
+    [setPosts]
+  );
+
+  const deletePost = useCallback(
+    async (id: string) => {
+      await authFetch(`/api/posts/${encodeURIComponent(id)}`, { method: "DELETE" });
+      setPosts((prev) => prev.filter((p) => p.id !== id));
+    },
+    [setPosts]
+  );
+
+  return {
+    posts,
+    setPosts,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    initialized,
+    fetchInitial,
+    fetchMore,
+    reset,
+    createPost,
+    updatePost,
+    deletePost,
+  };
+}

--- a/services/frontend/workspace/src/modules/post/lib/index.ts
+++ b/services/frontend/workspace/src/modules/post/lib/index.ts
@@ -1,1 +1,3 @@
 export * from "./mappers";
+export * from "./post-view";
+export * from "./post-mappers";

--- a/services/frontend/workspace/src/modules/post/lib/post-mappers.ts
+++ b/services/frontend/workspace/src/modules/post/lib/post-mappers.ts
@@ -22,10 +22,9 @@ export function mapPostAuthorToView(a: PostAuthor | undefined): PostAuthorView |
 }
 
 export function mapPostMediaToView(m: PostMedia): PostMediaView {
-  const t = (m.mediaType || "image") as "image" | "video";
   return {
     id: m.id || "",
-    mediaType: t === "video" ? "video" : "image",
+    mediaType: m.mediaType === "video" ? "video" : "image",
     url: m.url || "",
     thumbnailUrl: m.thumbnailUrl || "",
     mediaId: m.mediaId || "",
@@ -33,9 +32,8 @@ export function mapPostMediaToView(m: PostMedia): PostMediaView {
 }
 
 export function mapPostToView(p: Post): PostView {
-  const v = (p.visibility || "public").toLowerCase();
   return {
-    id: p.id,
+    id: p.id || "",
     authorId: p.authorId || "",
     content: p.content || "",
     media: (p.media || []).map(mapPostMediaToView),
@@ -43,7 +41,7 @@ export function mapPostToView(p: Post): PostView {
     author: mapPostAuthorToView(p.author),
     likesCount: p.likesCount || 0,
     commentsCount: p.commentsCount || 0,
-    visibility: v === "private" ? "private" : "public",
+    visibility: (p.visibility || "").toLowerCase() === "private" ? "private" : "public",
     hashtags: p.hashtags || [],
     liked: p.liked || false,
   };
@@ -56,7 +54,7 @@ export function mapPostsListResponse(res: {
 }): PostsListView {
   return {
     posts: (res.posts || []).map(mapPostToView),
-    nextCursor: res.nextCursor || "",
+    nextCursor: res.nextCursor || null,
     hasMore: res.hasMore || false,
   };
 }

--- a/services/frontend/workspace/src/modules/post/lib/post-mappers.ts
+++ b/services/frontend/workspace/src/modules/post/lib/post-mappers.ts
@@ -1,0 +1,78 @@
+import type {
+  Post,
+  PostAuthor,
+  PostMedia,
+} from "@/stub/post/v1/post_service_pb";
+import type {
+  PostAuthorView,
+  PostMediaView,
+  PostView,
+  PostsListView,
+  SavePostPayload,
+} from "@/modules/post/lib/post-view";
+
+export function mapPostAuthorToView(a: PostAuthor | undefined): PostAuthorView | null {
+  if (!a) return null;
+  return {
+    accountId: a.accountId || "",
+    displayName: a.displayName || "",
+    username: a.username || "",
+    avatarUrl: a.avatarUrl || "",
+  };
+}
+
+export function mapPostMediaToView(m: PostMedia): PostMediaView {
+  const t = (m.mediaType || "image") as "image" | "video";
+  return {
+    id: m.id || "",
+    mediaType: t === "video" ? "video" : "image",
+    url: m.url || "",
+    thumbnailUrl: m.thumbnailUrl || "",
+    mediaId: m.mediaId || "",
+  };
+}
+
+export function mapPostToView(p: Post): PostView {
+  const v = (p.visibility || "public").toLowerCase();
+  return {
+    id: p.id,
+    authorId: p.authorId || "",
+    content: p.content || "",
+    media: (p.media || []).map(mapPostMediaToView),
+    createdAt: p.createdAt || "",
+    author: mapPostAuthorToView(p.author),
+    likesCount: p.likesCount || 0,
+    commentsCount: p.commentsCount || 0,
+    visibility: v === "private" ? "private" : "public",
+    hashtags: p.hashtags || [],
+    liked: p.liked || false,
+  };
+}
+
+export function mapPostsListResponse(res: {
+  posts: Post[];
+  nextCursor: string;
+  hasMore: boolean;
+}): PostsListView {
+  return {
+    posts: (res.posts || []).map(mapPostToView),
+    nextCursor: res.nextCursor || "",
+    hasMore: res.hasMore || false,
+  };
+}
+
+export function buildSavePostRequest(payload: SavePostPayload) {
+  return {
+    id: payload.id || "",
+    content: payload.content,
+    media: (payload.media || []).map((m) => ({
+      id: "",
+      mediaType: m.mediaType,
+      url: "",
+      thumbnailUrl: "",
+      mediaId: m.mediaId,
+    })),
+    visibility: payload.visibility || "public",
+    hashtags: payload.hashtags || [],
+  };
+}

--- a/services/frontend/workspace/src/modules/post/lib/post-view.ts
+++ b/services/frontend/workspace/src/modules/post/lib/post-view.ts
@@ -1,0 +1,55 @@
+export interface PostAuthorView {
+  accountId: string;
+  displayName: string;
+  username: string;
+  avatarUrl: string;
+}
+
+export interface PostMediaView {
+  id: string;
+  mediaType: "image" | "video";
+  url: string;
+  thumbnailUrl: string;
+  mediaId: string;
+}
+
+export interface PostView {
+  id: string;
+  authorId: string;
+  content: string;
+  media: PostMediaView[];
+  createdAt: string;
+  author: PostAuthorView | null;
+  likesCount: number;
+  commentsCount: number;
+  visibility: "public" | "private";
+  hashtags: string[];
+  liked: boolean;
+}
+
+export interface SavePostMediaInput {
+  mediaType: "image" | "video";
+  mediaId: string;
+}
+
+export interface SavePostPayload {
+  id?: string;
+  content: string;
+  media?: SavePostMediaInput[];
+  visibility?: "public" | "private";
+  hashtags?: string[];
+}
+
+export interface PostsListView {
+  posts: PostView[];
+  nextCursor: string;
+  hasMore: boolean;
+}
+
+export interface PostLikeStatus {
+  liked: Record<string, boolean>;
+}
+
+export interface PostLikeResult {
+  likesCount: number;
+}

--- a/services/frontend/workspace/src/modules/post/lib/post-view.ts
+++ b/services/frontend/workspace/src/modules/post/lib/post-view.ts
@@ -42,7 +42,7 @@ export interface SavePostPayload {
 
 export interface PostsListView {
   posts: PostView[];
-  nextCursor: string;
+  nextCursor: string | null;
   hasMore: boolean;
 }
 


### PR DESCRIPTION
## Summary

Symmetric (account-authored) posts の **frontend 縦スライス** (data 層 + UI) を `src/modules/post` / `src/app/api/posts` / `src/app/posts` 配下に additive 追加。proto 側 (#652 / Q1-Q3b) の symmetric `PostService` / `LikeService` を消費し、投稿コンポーズ・PostCard binding・投稿詳細ページが揃う。

旧 `useCastPosts` / `useLike` / `useTimeline` / `useComments` と `/api/cast/*` / `/api/guest/*` / `/api/feed/*` は無改変 (feed / dev が消費中、cleanup フェーズで剥がす)。`/components/ui/*` primitive (`post-card`, `toggle`, `textarea`, `button` 等) も無改変。

## Commits

1. `0764cdef` **Q4a 実装**: 型 + mappers + 4 BFF route + 3 hook
2. `2df8d2ca` **Q4a review fix**: `extractPaginationParams` 統一、`nextCursor` sentinel 統一、`usePostLike` catch+log 追加、mapper 簡略化
3. `f230b46a` **Q4b 実装**: `PostCardBinding` + `PostComposer` + `/posts/[id]` 詳細ページ + `/dev/ui` mock セクション
4. `fcffcd2c` **Q4b review fix**: `PostCardBinding` useEffect の deps を `[post.id]` のみに絞り、SWR revalidate による like 巻き戻し race を防止

## What's added

### Q4a (data 層)
- 型 + mappers: `lib/post-view.ts` (`PostView` / `PostAuthorView` / `PostMediaView` / `SavePostPayload` / `PostsListView`)、`lib/post-mappers.ts` (proto Post → view 純関数 + `buildSavePostRequest`)
- BFF route: `/api/posts` (GET list + POST create)、`/api/posts/[id]` (GET + PUT + DELETE)、`/api/posts/[id]/like` (POST + DELETE)、`/api/posts/likes/status` (GET batch)
- hooks: `usePosts` (cursor pagination + create/update/delete)、`usePost` (single, SWR)、`usePostLike` (like / unlike / status / batch)
- barrel additive: `hooks/index.ts`, `lib/index.ts` (既存 export 保持して追記のみ)

### Q4b (UI 層)
- `modules/post/components/PostCardBinding.tsx`: `PostView` → 既存 `ui/post-card.tsx` adapter、`usePostLike` 内蔵で like toggle 完結、comment count + 詳細リンク + private アイコン
- `modules/post/components/PostComposer.tsx`: 投稿作成フォーム、純コンポーネント (`onSubmit` prop で fetch を親に委譲)、visibility toggle + 1000 文字カウンタ + エラーメッセージ
- `app/posts/[id]/page.tsx`: `useParams` + `usePost` + `PostCardBinding`、loading/error early return
- `app/dev/ui/page.tsx`: mock データで `PostCardBinding` / `PostComposer` をブラウザ視覚確認できるセクションを末尾 additive 追加

## Naming deviations from plan

- **`PostsListResult` → `PostsListView`**: 既存 `src/modules/post/types.ts` の `PostsListResult` (`CastPost` 用) と命名衝突するため。BFF response shape は plan 通り `{posts, nextCursor, hasMore}`。
- **`Toggle` props `pressed`/`onPressedChange` → `checked`/`onCheckedChange`**: `src/components/ui/toggle.tsx` の実 API に合わせる (primitive 無改変方針)。
- **error 色 `text-text-danger` → `text-error`**: `globals.css` 登録済 token に合わせる (`form-field.tsx` 等と一貫)。

## Test plan

- [x] `pnpm exec tsc --noEmit` 緑 (本 PR 完全クリーン)
- [x] `pnpm build` 緑、新 4 route (`/api/posts`, `/api/posts/[id]`, `/api/posts/[id]/like`, `/api/posts/likes/status`) + 新 page `/posts/[id]` がビルド出力に登場、旧 `/api/cast/*` / `/api/guest/*` / `/api/feed/*` / 旧 page 継続保持
- [ ] `pnpm lint`: 環境問題で動かず (`@typescript-eslint/utils@8.52.0` が ESLint 10 の `FlatESLint` と非互換、worktree / clean main 共通)。本 PR 範囲外、別途修正必要
- [ ] ブラウザ実機: `pnpm dev` で `/dev/ui` を開き、PostComposer / PostCardBinding mock を視覚確認 (controller 判断)
- [ ] e2e: monolith gRPC + frontend のローカルスタック (`[[local-e2e-run]]` メモリ手順) で `/posts/[id]` を実データで確認 (controller 判断)

## Known design debt (defer to Q5 / cleanup)

- `PostCardBinding` の `usePostLike` は instance-local state。detail page 1 件描画では問題ないが、**feed timeline (Q5) で並べた瞬間に同 post の like 状態が componentation 間で同期しない**。Q5 着手前に hook を context / store 化するか、liked/likesCount/onToggle を props 化する必要がある。

## Out of scope (deferred)

- comments の symmetric 化 & 一覧描画 → cleanup フェーズで ProfileService 化と同時 (Q4b は count 表示のみ)
- feed timeline (集約) → feed スライス (Q5)
- follow-gate (鍵アカ閲覧制限) → social スライス
- media 実アップロード e2e → object storage 配備後
- 投稿編集 / 削除 UI (`usePosts.updatePost` / `deletePost`) → Q4b ではコンポーズのみ
- 旧 `CastPost` 系 / 旧 BFF / 旧 column の撤去 → cleanup フェーズ
- `pnpm lint` 環境問題 → 別 PR で `@typescript-eslint/utils` 系 pin 修正

Plan: [`Q4a`](docs/superpowers/plans/2026-06-08-posts-q4a-frontend-data-layer.md) / [`Q4b`](docs/superpowers/plans/2026-06-08-posts-q4b-frontend-ui.md)
Spec: [`docs/superpowers/specs/2026-06-07-posts-slice-design.md`](docs/superpowers/specs/2026-06-07-posts-slice-design.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Full post management: create, view, update, and delete posts.
  * Like and unlike functionality for posts.
  * Individual post detail page accessible at `/posts/[id]`.
  * Post composer interface for creating new posts.
  * Post cards displaying author information and engagement metrics.
  * Paginated post listing and browsing.

* **Documentation**
  * Added implementation plans for Q4a (data layer) and Q4b (UI).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->