### PR TITLE
feat(feed): symmetric feed home (3-tab) + /dev/ui mock

### DIFF
--- a/docs/superpowers/plans/2026-06-12-feed-f4b-ui.md
+++ b/docs/superpowers/plans/2026-06-12-feed-f4b-ui.md
@@ -1,0 +1,300 @@
+# Feed F4b: frontend UI (`/` home + 3-tab feed + /dev/ui mock) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** F4a (`useFeed` hook + `/api/feed` BFF) を消費する **frontend UI 層**を実装する: ルート `/` (ホーム) を 3 タブ (全員 / エリア / フォロー中) の feed timeline に置き換え、`PostCardBinding` (Q4b、#653) を再利用してリスト描画。AREA タブは viewer の `useProfile().prefecture` を初期値に使用。`/dev/ui` に mock データで feed セクションを additive 追加。
+
+**Architecture:** **Additive、build-green**。Q4a の `PostView` / `mapPostToView`、Q4b の `PostCardBinding`、F4a の `useFeed` を再利用。新規は (1) `/` ホームページ実装 (現状 placeholder の置換)、(2) `/dev/ui` への mock 追加、(3) 必要なら小さな `FeedTabsHeader` / `FeedPostList` ヘルパ。旧 `useTimeline` / 旧 `/api/feed/{cast,guest}` BFF は無改変、cleanup フェーズで drop。
+
+**Tech Stack:** Next.js 16 / React 19 / TypeScript / Tailwind / pnpm。既存 `ui/post-card.tsx`、`ui/tab.tsx`、`PostCardBinding`、`useFeed` (F4a)、`useProfile` (Q4a / profile P5)。
+
+**Spec:** `docs/superpowers/specs/2026-06-12-feed-slice-design.md` (§Frontend / §Decomposition の F4)。前提: F4a (#664) + Q4a/Q4b posts (#653) + Q4b post-like hoist (#654) + profile P5 / posts F3 (#663) main マージ済、main HEAD = `eb497533`。
+
+---
+
+## Context for the implementer
+
+- worktree: `/Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-feed-f4b-ui`。frontend app root: `services/frontend/workspace`。branch `feat/feed-f4b-ui` (origin/main = `eb497533` base、tracking 済)。**push しない**。
+- 検索は `/usr/bin/grep` / `/usr/bin/find`。import alias `@/` → `src/`。
+- **テストランナーは無い**。検証は `pnpm exec tsc --noEmit` (緑必須) + `pnpm build` (緑必須) + `pnpm lint` (新 violation 出さない、baseline = 27 problems と同等)。
+- ブラウザ実機確認は controller (親) が puppeteer で `/dev/ui` をキャプチャ予定。
+- **build-green / additive**: 以下は無改変:
+  - F4a の `src/modules/feed/{types,lib/mappers,hooks/useFeed}.ts` + `src/app/api/feed/route.ts`
+  - 旧 `src/modules/post/hooks/{useTimeline,useGuestPost,...}.ts`、旧 `/api/feed/{cast,guest}` BFF
+  - Q4a / Q4b の `src/modules/post/lib/post-view.ts` / `post-mappers.ts` / `components/PostCardBinding.tsx` / `hooks/{usePostLike,usePost,usePosts}.ts`
+  - `src/components/ui/*` primitive (`post-card`、`tab`、`button` 等)
+  - `src/lib/grpc.ts` / 他 core lib
+
+### 既存パターン (踏襲する)
+
+- **`Tabs`** (`src/components/ui/tab.tsx`):
+  ```ts
+  <Tabs items={[{id, label}, ...]} value={current} onValueChange={(id) => ...} />
+  ```
+- **`PostCardBinding`** (`src/modules/post/components/PostCardBinding.tsx`、Q4b):
+  ```tsx
+  <PostCardBinding post={postView} detailHref?={...} className?={...} />
+  ```
+  内部で `usePostLike` (Zustand store backing) を使って like 状態を共有、`/posts/${id}` 詳細リンク付き
+- **`useFeed`** (`src/modules/feed/hooks/useFeed.ts`、F4a):
+  ```ts
+  const { posts, loading, loadingMore, error, hasMore, initialized, fetchInitial, fetchMore, reset, filter, prefecture } = useFeed({ filter, prefecture });
+  ```
+- **`useProfile`** (`src/modules/profile/hooks/useProfile.ts`、Q4a):
+  ```ts
+  const { profile, loading, error, ... } = useProfile();
+  // profile?.prefecture: string (空文字 or 都道府県名)
+  ```
+- **`/dev/ui` 構造** (`src/app/dev/ui/page.tsx`): `"use client"` + 各 component の mock セクション。Q4b で `PostComposer` と `PostCardBinding` を追加、F4b は **feed プレビュー**を additive 追加 (3 タブ + 数件の mock posts)。
+
+## File Structure
+
+- Modify: `src/app/page.tsx` — placeholder 撤去、symmetric feed timeline (3 タブ + `PostCardBinding` リスト + load more) で置き換え
+- Modify: `src/app/dev/ui/page.tsx` — mock feed セクション (3 タブ + 3-4 件の mock `PostView`) を additive 追加
+
+> 新規 component を作らない方針 (`/` page 内の useState で十分、`/dev/ui` も mock 配列で済む)。再利用するのは `Tabs` / `PostCardBinding` / `useFeed` / `useProfile`。
+
+---
+
+## Task 1: `/` ホームページを feed timeline に置き換え
+
+**Files:** Modify `src/app/page.tsx`。
+
+- [ ] **Step 1: 全置換**
+
+```tsx
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Tabs, type TabItem } from "@/components/ui/tab";
+import { Button } from "@/components/ui/button";
+import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+import { useFeed } from "@/modules/feed/hooks/useFeed";
+import { useProfile } from "@/modules/profile/hooks/useProfile";
+import type { FeedFilterValue } from "@/modules/feed/types";
+
+const TAB_ITEMS: TabItem[] = [
+  { id: "all", label: "全員" },
+  { id: "area", label: "エリア" },
+  { id: "following", label: "フォロー中" },
+];
+
+export default function HomePage() {
+  const [filter, setFilter] = useState<FeedFilterValue>("all");
+  const { profile } = useProfile();
+  const prefecture = filter === "area" ? profile?.prefecture || undefined : undefined;
+
+  const {
+    posts,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    initialized,
+    fetchInitial,
+    fetchMore,
+    reset,
+  } = useFeed({ filter, prefecture });
+
+  // Re-fetch when filter or prefecture changes.
+  useEffect(() => {
+    reset();
+    fetchInitial();
+    // fetchInitial / reset are stable from usePaginatedFetch; we intentionally depend on
+    // filter and prefecture so a tab switch (or profile-loaded prefecture) refreshes the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter, prefecture]);
+
+  const showAreaHint = filter === "area" && !prefecture;
+  const showEmptyState = initialized && !loading && posts.length === 0 && !showAreaHint;
+
+  const content = useMemo(() => {
+    if (!initialized && loading) {
+      return <p className="px-4 py-8 text-center text-text-secondary">読み込み中…</p>;
+    }
+    if (error) {
+      return <p className="px-4 py-8 text-center text-text-danger">読み込みに失敗しました</p>;
+    }
+    if (showAreaHint) {
+      return (
+        <p className="px-4 py-8 text-center text-text-secondary">
+          エリアタブを使うにはプロフィールに都道府県を設定してください。
+        </p>
+      );
+    }
+    if (showEmptyState) {
+      return <p className="px-4 py-8 text-center text-text-secondary">まだ投稿がありません</p>;
+    }
+    return (
+      <>
+        {posts.map((post) => (
+          <PostCardBinding key={post.id} post={post} />
+        ))}
+        {hasMore && (
+          <div className="px-4 py-4 text-center">
+            <Button
+              variant="secondary"
+              onClick={() => fetchMore()}
+              disabled={loadingMore}
+            >
+              {loadingMore ? "読み込み中…" : "もっと見る"}
+            </Button>
+          </div>
+        )}
+      </>
+    );
+  }, [initialized, loading, error, showAreaHint, showEmptyState, posts, hasMore, loadingMore, fetchMore]);
+
+  return (
+    <main className="mx-auto flex max-w-xl flex-col bg-bg text-text-primary">
+      <header className="sticky top-0 z-10 bg-bg">
+        <Tabs
+          items={TAB_ITEMS}
+          value={filter}
+          onValueChange={(id) => setFilter(id as FeedFilterValue)}
+        />
+      </header>
+      <section>{content}</section>
+    </main>
+  );
+}
+```
+
+**実装上の注意**:
+- `useEffect` の deps を `[filter, prefecture]` のみに絞り、`fetchInitial` / `reset` を含めない (Q4b の `PostCardBinding` で確立した「stable callbacks + 意図的に絞った deps + eslint-disable コメント」パターン)
+- `prefecture = filter === "area" ? profile?.prefecture : undefined` で AREA 以外では prefecture を送らない (BFF が `prefecture` 空文字で受け、backend が ALL/FOLLOWING で無視)
+- viewer が未ログインや profile 未取得時: `profile?.prefecture` は undefined → `showAreaHint` で「都道府県を設定してください」表示
+- empty / error / loading / hasMore / loadMore button のシンプルな状態管理
+- `Tabs` の `onValueChange` 戻り値は `string` なので `as FeedFilterValue` で narrow (3 値固定なので安全)
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+cd services/frontend/workspace && pnpm exec tsc --noEmit 2>&1 | /usr/bin/tail -15
+```
+
+緑必須。
+
+---
+
+## Task 2: `/dev/ui` に mock feed セクションを additive 追加
+
+**Files:** Modify `src/app/dev/ui/page.tsx`。
+
+- [ ] **Step 1: 既存セクションを Read で確認、import を additive 追加**
+
+ファイル冒頭の import 群末尾 (`PostCardBinding` 等の下) に以下を追加:
+
+```tsx
+import { Tabs, type TabItem } from "@/components/ui/tab";
+import type { FeedFilterValue } from "@/modules/feed/types";
+```
+
+(既存 `import { PostCardBinding }` 等は変更しない、まだ未 import なら追加)
+
+- [ ] **Step 2: 既存 `mockPosts` の下に feed 用 state + 追加 mock を additive 定義**
+
+`useState("home")` 等の既存 state hook 群の末尾に追加:
+
+```tsx
+  const [feedFilter, setFeedFilter] = useState<FeedFilterValue>("all");
+  const FEED_TAB_ITEMS: TabItem[] = [
+    { id: "all", label: "全員" },
+    { id: "area", label: "エリア" },
+    { id: "following", label: "フォロー中" },
+  ];
+```
+
+(`useState` import は既存)
+
+- [ ] **Step 3: セクションを `<main>` 末尾の `</main>` 直前に additive 追加**
+
+既存 `PostCardBinding` セクション (Q4b で追加済、`mockPosts` を map で描画している) の**下に新セクション**:
+
+```tsx
+      <section className="flex flex-col">
+        <h2 className="px-4 pb-3 text-sm font-bold text-text-secondary">Feed (3-tab home)</h2>
+        <Tabs
+          items={FEED_TAB_ITEMS}
+          value={feedFilter}
+          onValueChange={(id) => setFeedFilter(id as FeedFilterValue)}
+        />
+        <div>
+          {mockPosts.map((p) => (
+            <PostCardBinding key={`feed-${feedFilter}-${p.id}`} post={p} />
+          ))}
+        </div>
+      </section>
+```
+
+(既存 `mockPosts` 配列を再利用、key は `feed-${filter}-${id}` で `PostCardBinding` セクションとぶつからないように)
+
+- [ ] **Step 4: 型チェック**
+
+```bash
+pnpm exec tsc --noEmit 2>&1 | /usr/bin/tail -15
+```
+
+緑必須。
+
+---
+
+## Task 3: build / lint で検証 + commit
+
+- [ ] **Step 1: 本番ビルド**
+
+```bash
+cd services/frontend/workspace && pnpm build 2>&1 | /usr/bin/tail -30
+```
+
+成功必須。`/` ルート (旧 placeholder) が **dynamic に変化** することがビルド出力で確認できるはず (`useFeed` 等の client hook 経由)。`/dev/ui` も継続出力。
+
+- [ ] **Step 2: lint**
+
+```bash
+pnpm lint 2>&1 | /usr/bin/tail -25
+```
+
+新 violation を出さないこと (baseline = 27 problems 同等)。Q4b で確立した `eslint-disable-next-line react-hooks/exhaustive-deps` パターンを `page.tsx:useEffect` で踏襲、追加 violation を生じさせない。
+
+- [ ] **Step 3: diff stat 確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-feed-f4b-ui
+/usr/bin/git diff --stat origin/main HEAD
+```
+
+期待: 3 ファイル変更 (`page.tsx`、`dev/ui/page.tsx`、plan)。**他のファイル変更ゼロ** (F4a の `useFeed` / `/api/feed` route、Q4a/Q4b の posts components、primitive 全て無 diff)。
+
+- [ ] **Step 4: コミット (signoff、Co-Authored-By 無し)**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-feed-f4b-ui
+/usr/bin/git add services/frontend/workspace/src/app/page.tsx services/frontend/workspace/src/app/dev/ui/page.tsx docs/superpowers/plans/2026-06-12-feed-f4b-ui.md
+/usr/bin/git commit -s -m "feat(feed): symmetric feed home (3-tab) + /dev/ui mock"
+```
+
+push しない (controller 判断)。
+
+---
+
+## Deferred (本 F4b では実施しない)
+
+- **旧 `useTimeline` / `useGuestPost` hook、`/api/feed/cast` / `/api/feed/guest` BFF の drop** → cleanup PR で旧 RPC drop と同時
+- **AREA タブの prefecture UI 変更機能** (UI で都道府県を切り替える) → viewer.profile.prefecture 固定で発進、後で UI 追加
+- **「投稿する」FAB / Composer 表示** → 別 PR (Q4b の `PostComposer` を home に置く UX 設計を別途検討)
+- **無限スクロール (IntersectionObserver)** → 「もっと見る」ボタンで発進、後で UX 改善
+- **未ログイン時の login 誘導 UI** → 現状は error or empty で degrade、後で polish
+- **NSFW / 年齢ゲート / hashtag / mute** → 別スライス
+
+## Self-Review (作成者チェック済)
+
+- **Spec coverage (F4b 範囲)**: spec §Frontend の「タブ component で 3 タブ切替 + `PostCardBinding` 再利用 + 投稿一覧ページ = `/` ルート (rx-sns 踏襲)」を完全実装。`/dev/ui` mock セクションも追加で visual 確認可能。
+- **Additive / build-green**: F4a の `useFeed` / `/api/feed` route、Q4a/Q4b posts data/UI、primitive 全て無改変。変更は 2 ファイル (page + dev/ui) + plan。
+- **Placeholder 無し**: 全 task に完全コード。
+- **型 / 命名整合**:
+  - `FeedFilterValue` (F4a) を `useState`、`onValueChange` の `as FeedFilterValue` narrowing で使用
+  - `useFeed({ filter, prefecture })` シグネチャに合わせる (F4a の `UseFeedOptions`)
+  - `PostCardBinding post={postView}` (Q4b API 不変)
+  - `useProfile().profile?.prefecture` (Q4a)
+- **テスト方針**: frontend ランナー無し → `pnpm build` (tsc) + `pnpm lint`。controller が puppeteer で `/dev/ui` キャプチャして視覚確認。実 backend e2e は `[[local-e2e-run]]` メモリ手順で controller 判断。

--- a/services/frontend/workspace/src/app/dev/ui/page.tsx
+++ b/services/frontend/workspace/src/app/dev/ui/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Tabs } from "@/components/ui/tab";
+import { Tabs, type TabItem } from "@/components/ui/tab";
 import { Toggle } from "@/components/ui/toggle";
 import { Avatar } from "@/components/ui/avatar";
 import { UserCard } from "@/components/ui/user-card";
@@ -19,6 +19,7 @@ import type { ProfileView, AreaView } from "@/modules/profile/types";
 import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
 import { PostComposer } from "@/modules/post/components/PostComposer";
 import type { PostView, SavePostPayload } from "@/modules/post/lib/post-view";
+import type { FeedFilterValue } from "@/modules/feed/types";
 
 export default function DevUiPage() {
   const [tab, setTab] = useState("home");
@@ -28,6 +29,12 @@ export default function DevUiPage() {
   const [prefecture, setPrefecture] = useState("東京都");
   const [editOpen, setEditOpen] = useState(false);
   const [areaSel, setAreaSel] = useState<string[]>(["1"]);
+  const [feedFilter, setFeedFilter] = useState<FeedFilterValue>("all");
+  const FEED_TAB_ITEMS: TabItem[] = [
+    { id: "all", label: "全員" },
+    { id: "area", label: "エリア" },
+    { id: "following", label: "フォロー中" },
+  ];
   const mockAreas: AreaView[] = [
     { id: "1", region: "関東", prefecture: "東京都", name: "渋谷", code: "shibuya" },
     { id: "2", region: "関東", prefecture: "東京都", name: "新宿", code: "shinjuku" },
@@ -222,6 +229,20 @@ export default function DevUiPage() {
         {mockPosts.map((p) => (
           <PostCardBinding key={p.id} post={p} />
         ))}
+      </section>
+
+      <section className="flex flex-col">
+        <h2 className="px-4 pb-3 text-sm font-bold text-text-secondary">Feed (3-tab home)</h2>
+        <Tabs
+          items={FEED_TAB_ITEMS}
+          value={feedFilter}
+          onValueChange={(id) => setFeedFilter(id as FeedFilterValue)}
+        />
+        <div>
+          {mockPosts.map((p) => (
+            <PostCardBinding key={`feed-${feedFilter}-${p.id}`} post={p} />
+          ))}
+        </div>
       </section>
     </main>
   );

--- a/services/frontend/workspace/src/app/page.tsx
+++ b/services/frontend/workspace/src/app/page.tsx
@@ -1,8 +1,95 @@
-export default function Home() {
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Tabs, type TabItem } from "@/components/ui/tab";
+import { Button } from "@/components/ui/button";
+import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+import { useFeed } from "@/modules/feed/hooks/useFeed";
+import { useProfile } from "@/modules/profile/hooks/useProfile";
+import type { FeedFilterValue } from "@/modules/feed/types";
+
+const TAB_ITEMS: TabItem[] = [
+  { id: "all", label: "全員" },
+  { id: "area", label: "エリア" },
+  { id: "following", label: "フォロー中" },
+];
+
+export default function HomePage() {
+  const [filter, setFilter] = useState<FeedFilterValue>("all");
+  const { profile } = useProfile();
+  const prefecture = filter === "area" ? profile?.prefecture || undefined : undefined;
+
+  const {
+    posts,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    initialized,
+    fetchInitial,
+    fetchMore,
+    reset,
+  } = useFeed({ filter, prefecture });
+
+  // Re-fetch when filter or prefecture changes.
+  useEffect(() => {
+    reset();
+    fetchInitial();
+    // fetchInitial / reset are stable from usePaginatedFetch; we intentionally depend on
+    // filter and prefecture so a tab switch (or profile-loaded prefecture) refreshes the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter, prefecture]);
+
+  const showAreaHint = filter === "area" && !prefecture;
+  const showEmptyState = initialized && !loading && posts.length === 0 && !showAreaHint;
+
+  const content = useMemo(() => {
+    if (!initialized && loading) {
+      return <p className="px-4 py-8 text-center text-text-secondary">読み込み中…</p>;
+    }
+    if (error) {
+      return <p className="px-4 py-8 text-center text-text-danger">読み込みに失敗しました</p>;
+    }
+    if (showAreaHint) {
+      return (
+        <p className="px-4 py-8 text-center text-text-secondary">
+          エリアタブを使うにはプロフィールに都道府県を設定してください。
+        </p>
+      );
+    }
+    if (showEmptyState) {
+      return <p className="px-4 py-8 text-center text-text-secondary">まだ投稿がありません</p>;
+    }
+    return (
+      <>
+        {posts.map((post) => (
+          <PostCardBinding key={post.id} post={post} />
+        ))}
+        {hasMore && (
+          <div className="px-4 py-4 text-center">
+            <Button
+              variant="secondary"
+              onClick={() => fetchMore()}
+              disabled={loadingMore}
+            >
+              {loadingMore ? "読み込み中…" : "もっと見る"}
+            </Button>
+          </div>
+        )}
+      </>
+    );
+  }, [initialized, loading, error, showAreaHint, showEmptyState, posts, hasMore, loadingMore, fetchMore]);
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-2 bg-bg p-6 text-center">
-      <h1 className="text-2xl font-bold text-text-primary">Under construction</h1>
-      <p className="text-text-secondary">再構築中です</p>
+    <main className="mx-auto flex max-w-xl flex-col bg-bg text-text-primary">
+      <header className="sticky top-0 z-10 bg-bg">
+        <Tabs
+          items={TAB_ITEMS}
+          value={filter}
+          onValueChange={(id) => setFilter(id as FeedFilterValue)}
+        />
+      </header>
+      <section>{content}</section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Feed slice Q5 シリーズの **F4b** = symmetric feed の **UI 結線** (Q5 最終増分)。ルート `/` (placeholder) を 3 タブ (全員 / エリア / フォロー中) の symmetric feed timeline に置き換え、F4a の `useFeed` + Q4b の `PostCardBinding` を再利用。AREA タブは viewer の `useProfile().prefecture` を初期値に使う。`/dev/ui` には mock データで Feed セクションを additive 追加。

これで Q5 (F1 proto → F2 posts hydration → F3a profile prefecture → F3 feed handler → F4a frontend data → F4b frontend UI) が完了。

## Commit

- `e4311414` **本実装** (3 ファイル / +413 / -5):
  - `app/page.tsx` 全置換: 3 タブ `<Tabs>` + `useFeed({filter, prefecture})` + `PostCardBinding` リスト + 「もっと見る」ボタン (cursor pagination) + loading / error / empty / AREA hint の状態管理。tab 切替・prefecture 変化で `reset() + fetchInitial()`、deps を `[filter, prefecture]` のみに絞り `// eslint-disable-next-line react-hooks/exhaustive-deps` で意図明示 (Q4b PostCardBinding 同パターン)
  - `app/dev/ui/page.tsx` additive: Feed セクション (`<Tabs>` + 既存 mockPosts を `PostCardBinding` で描画) を末尾に追加、既存 Q4b セクションは不変
  - `docs/superpowers/plans/2026-06-12-feed-f4b-ui.md` plan 同梱

## Additive 保持

- F4a の `useFeed` / `/api/feed` route / feed mappers / feed types、Q4a / Q4b posts 産物、`PostCardBinding` / `usePostLike` / `postLikeStore`、primitive (`Tabs` / `PostCard` 等) 全て **0 行変更**
- 検証: `git diff origin/main HEAD -- services/frontend/workspace/src/modules services/frontend/workspace/src/components services/frontend/workspace/src/app/api services/frontend/workspace/src/lib` → 0 行
- 変更は 2 source + plan = 3 ファイル

## Verification

- [x] `pnpm exec tsc --noEmit` 緑
- [x] `pnpm build` 緑、`/` route 出現
- [x] `pnpm lint`: **27 problems (7 errors, 20 warnings)** = baseline と完全同等、新 violation ゼロ
- [x] ブラウザ実機 puppeteer:
  - `/dev/ui` の Feed セクション = 3 タブ + `PostCardBinding` 2 件正常描画
  - `/` home = タブ表示 OK、未認証で `/api/feed` 401 → "読み込みに失敗しました" の **graceful degrade** (Plan の Deferred 「未ログイン UI は別 PR」明記済の意図通り)

## Implementation note: `/` static prerender 継続

Plan は「`useFeed` 経由で `/` が static → dynamic に変化」と予想したが、実測は `○ /` (static) のまま。Next.js 16 では client component (`"use client"`) でも内部 state / client-side fetch のみなら static prerender を妨げない。機能的には正常 (client-side hydration で `/api/feed` fetch が走る)、UI 動作影響なし。

## Known limitations (defer to follow-up)

- **旧 `useTimeline` / `useGuestPost` hook、`/api/feed/cast` / `/api/feed/guest` BFF の drop** → cleanup PR で旧 RPC drop と同時
- **AREA タブの prefecture UI 変更**: viewer.profile.prefecture 固定、後で UI 追加
- **未ログイン時の login 誘導 UI**: graceful degrade で発進、後で polish
- **無限スクロール**: 「もっと見る」ボタンで発進、後で IntersectionObserver
- **NSFW / 年齢ゲート / hashtag / mute**: 別スライス

## Q5 シリーズ完了

| PR | 内容 |
|---|---|
| #660 | F1 proto + design spec |
| #661 | F2 posts cross-slice hydration |
| #662 | F3a profile prefecture lookup |
| #663 | F3 feed handler + use_case + adapter symmetric |
| #664 | F4a frontend data layer |
| **本 PR** | F4b frontend UI |

次は cleanup フェーズ (旧 RPC / message / use_cases / cast-guest adapter / BFFs / hooks の drop)。

Spec: [\`docs/superpowers/specs/2026-06-12-feed-slice-design.md\`](docs/superpowers/specs/2026-06-12-feed-slice-design.md)
Plan: [\`docs/superpowers/plans/2026-06-12-feed-f4b-ui.md\`](docs/superpowers/plans/2026-06-12-feed-f4b-ui.md)