### PR TITLE
feat(social): schema migration + slice base + relations + repositories

### DIFF
--- a/docs/superpowers/plans/2026-06-15-social-s2a-schema-repo.md
+++ b/docs/superpowers/plans/2026-06-15-social-s2a-schema-repo.md
@@ -1,0 +1,524 @@
+# Social S2a: schema + relations + repositories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** monolith に `slices/social/` 新規スライスを greenfield 作成し、DB schema `social` + 2 table (`follows` / `blocks`) + relations + 2 repositories まで配置する。use_cases / handlers は **S2b** で実装。
+
+**Architecture:** **Greenfield additive**。新 PostgreSQL schema `social` (旧 `social.*` テーブルは 2026-02-16 migration で全て `relationship` / `post` に移動済みなので空)。Hanami slice 規約に従い `slices/social/` 配下に最小構成 (`db/{relation,repo}.rb`、`relations/{follows,blocks}.rb`、`repositories/{follow,block}_repository.rb`)。symmetric `follower_id` / `followee_id`、`blocker_id` / `blocked_id` 列。Block の auto-unfollow transaction は repository に持たせる。
+
+**Tech Stack:** Ruby / Hanami 2 / ROM / Sequel / PostgreSQL。
+
+**Spec:** `docs/superpowers/specs/2026-06-15-social-slice-design.md` (§Domain model / §Monolith social slice の schema / relations / repository)。
+
+---
+
+## Context
+
+- worktree: `/Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-social-s2-monolith`、branch `feat/social-s2-monolith` (origin/main = `4baac9b5` base、S1 #676 マージ後)。**push しない**、PR は親が判断。
+- 検索は `/usr/bin/grep` / `/usr/bin/find`。
+- DB: localhost:5432 (postgres/password/monolith)、`hanami` は postgres@18 path 想定 (`export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"`)。
+- 触らない: 旧 `slices/relationship/*`、他 slice、proto、frontend。
+
+### 既存パターン (踏襲)
+
+- migration: `ROM::SQL.migration do ... up do ... down do` (例: `config/db/migrate/20260207000000_create_blocks.rb`)
+- schema: `:"social__follows"` (PostgreSQL schema = `social`、table = `follows`、ROM の `__` 命名規約)
+- slice base: `module Social; module DB; class Relation < Monolith::DB::Relation; end; end; end` (relationship slice と同形)
+- relation: `schema(:"social__follows", as: :follows, infer: false) do ... attribute ... primary_key :id end`
+- repository: `class FollowRepository < Social::DB::Repo` で `follows` relation 使用
+
+## File Structure
+
+- Create: `services/monolith/workspace/config/db/migrate/20260615000000_create_social_schema.rb`
+- Create: `services/monolith/workspace/slices/social/db/relation.rb`
+- Create: `services/monolith/workspace/slices/social/db/repo.rb`
+- Create: `services/monolith/workspace/slices/social/relations/follows.rb`
+- Create: `services/monolith/workspace/slices/social/relations/blocks.rb`
+- Create: `services/monolith/workspace/slices/social/repositories/follow_repository.rb`
+- Create: `services/monolith/workspace/slices/social/repositories/block_repository.rb`
+
+---
+
+## Task 1: migration 作成 + 実行
+
+**Files:** Create `services/monolith/workspace/config/db/migrate/20260615000000_create_social_schema.rb`。
+
+- [ ] **Step 1: 実装**
+
+```ruby
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  up do
+    run "CREATE SCHEMA IF NOT EXISTS social"
+
+    create_table :"social__follows" do
+      column :id, :uuid, null: false
+      column :follower_id, :uuid, null: false
+      column :followee_id, :uuid, null: false
+      column :status, :text, null: false, default: "approved"  # "pending" | "approved"
+      column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+      column :updated_at, :timestamptz, null: false, default: Sequel.lit("now()")
+
+      primary_key [:id]
+      unique [:follower_id, :followee_id]
+      index :follower_id
+      index :followee_id
+      index [:followee_id, :status]
+    end
+
+    create_table :"social__blocks" do
+      column :id, :uuid, null: false
+      column :blocker_id, :uuid, null: false
+      column :blocked_id, :uuid, null: false
+      column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+
+      primary_key [:id]
+      unique [:blocker_id, :blocked_id]
+      index :blocker_id
+      index :blocked_id
+    end
+  end
+
+  down do
+    drop_table :"social__blocks"
+    drop_table :"social__follows"
+    run "DROP SCHEMA IF EXISTS social CASCADE"
+  end
+end
+```
+
+- [ ] **Step 2: migration 実行**
+
+```bash
+cd services/monolith/workspace
+export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
+bundle exec hanami db migrate 2>&1 | /usr/bin/tail -5
+```
+
+Expected: `=> database monolith migrated in N.NNNs` + `monolith_test migrated` 両方緑。
+
+- [ ] **Step 3: 確認**
+
+```bash
+PGPASSWORD=password psql -h localhost -U postgres -d monolith -c "\dt social.*"
+PGPASSWORD=password psql -h localhost -U postgres -d monolith -c "\d social.follows"
+```
+
+Expected: `social.follows` / `social.blocks` 2 テーブル、カラム + index + unique constraint 確認。
+
+---
+
+## Task 2: slice base (`db/relation.rb` + `db/repo.rb`)
+
+**Files:** Create 2 files。
+
+- [ ] **Step 1: `slices/social/db/relation.rb`**
+
+```ruby
+# frozen_string_literal: true
+
+module Social
+  module DB
+    class Relation < Monolith::DB::Relation
+    end
+  end
+end
+```
+
+- [ ] **Step 2: `slices/social/db/repo.rb`**
+
+```ruby
+# frozen_string_literal: true
+
+module Social
+  module DB
+    class Repo < Monolith::DB::Repo
+    end
+  end
+end
+```
+
+- [ ] **Step 3: 構文チェック**
+
+```bash
+ruby -c slices/social/db/relation.rb slices/social/db/repo.rb
+```
+
+両方 `Syntax OK`。
+
+---
+
+## Task 3: relations (`follows.rb` + `blocks.rb`)
+
+**Files:** Create 2 files。
+
+- [ ] **Step 1: `slices/social/relations/follows.rb`**
+
+```ruby
+# frozen_string_literal: true
+
+module Social
+  module Relations
+    class Follows < Social::DB::Relation
+      schema(:"social__follows", as: :follows, infer: false) do
+        attribute :id, Types::String
+        attribute :follower_id, Types::String
+        attribute :followee_id, Types::String
+        attribute :status, Types::String
+        attribute :created_at, Types::Time
+        attribute :updated_at, Types::Time
+
+        primary_key :id
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: `slices/social/relations/blocks.rb`**
+
+```ruby
+# frozen_string_literal: true
+
+module Social
+  module Relations
+    class Blocks < Social::DB::Relation
+      schema(:"social__blocks", as: :blocks, infer: false) do
+        attribute :id, Types::String
+        attribute :blocker_id, Types::String
+        attribute :blocked_id, Types::String
+        attribute :created_at, Types::Time
+
+        primary_key :id
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: 構文チェック**
+
+```bash
+ruby -c slices/social/relations/follows.rb slices/social/relations/blocks.rb
+```
+
+両方 `Syntax OK`。
+
+---
+
+## Task 4: `FollowRepository`
+
+**Files:** Create `services/monolith/workspace/slices/social/repositories/follow_repository.rb`。
+
+- [ ] **Step 1: 実装**
+
+```ruby
+# frozen_string_literal: true
+
+require "concerns/cursor_pagination"
+
+module Social
+  module Repositories
+    # Symmetric follow repository. follower_id/followee_id are both account_ids.
+    # status is "approved" (immediate, default for public targets) or "pending" (private targets).
+    class FollowRepository < Social::DB::Repo
+      include Concerns::CursorPagination
+
+      # --- Mutations ----
+
+      # Insert or no-op. Returns the resulting status (existing or new).
+      # @return [Hash{success: Boolean, status: String, reason: Symbol?}]
+      def follow(follower_id:, followee_id:, status:)
+        existing = follows.where(follower_id: follower_id, followee_id: followee_id).one
+        return { success: false, status: existing.status, reason: :already_exists } if existing
+
+        follows.changeset(:create,
+          id: SecureRandom.uuid_v7,
+          follower_id: follower_id,
+          followee_id: followee_id,
+          status: status,
+          updated_at: Time.now
+        ).commit
+        { success: true, status: status }
+      end
+
+      def unfollow(follower_id:, followee_id:)
+        follows.dataset.where(follower_id: follower_id, followee_id: followee_id).delete > 0
+      end
+
+      def update_status(follower_id:, followee_id:, status:)
+        updated = follows.dataset
+          .where(follower_id: follower_id, followee_id: followee_id)
+          .update(status: status, updated_at: Time.now)
+        updated > 0
+      end
+
+      # Delete both directions (used by Block transaction in BlockRepository).
+      def remove_bidirectional(account_a:, account_b:)
+        follows.dataset
+          .where(
+            Sequel.|(
+              { follower_id: account_a, followee_id: account_b },
+              { follower_id: account_b, followee_id: account_a }
+            )
+          )
+          .delete
+      end
+
+      # --- Reads ----
+
+      def find(follower_id:, followee_id:)
+        follows.where(follower_id: follower_id, followee_id: followee_id).one
+      end
+
+      def list_following(account_id:, status: "approved", limit: 20, cursor: nil)
+        scope = follows.where(follower_id: account_id, status: status)
+        scope = apply_cursor(scope, cursor)
+        scope.order { [created_at.desc, id.desc] }.limit(limit + 1).to_a
+      end
+
+      def list_followers(account_id:, status: "approved", limit: 20, cursor: nil)
+        scope = follows.where(followee_id: account_id, status: status)
+        scope = apply_cursor(scope, cursor)
+        scope.order { [created_at.desc, id.desc] }.limit(limit + 1).to_a
+      end
+
+      def list_pending_to(account_id:, limit: 20, cursor: nil)
+        list_followers(account_id: account_id, status: "pending", limit: limit, cursor: cursor)
+      end
+
+      def count_pending_to(account_id:)
+        follows.where(followee_id: account_id, status: "pending").count
+      end
+
+      # @return [Hash{target_account_id (String) => status (String)}], missing keys = no row
+      def status_batch(follower_id:, followee_ids:)
+        return {} if followee_ids.nil? || followee_ids.empty?
+
+        rows = follows.dataset
+          .where(follower_id: follower_id, followee_id: followee_ids)
+          .select_map([:followee_id, :status])
+        rows.each_with_object({}) { |(target, status), h| h[target.to_s] = status }
+      end
+
+      # Used by Feed FOLLOWING tab (already exposed since F3).
+      def following_account_ids(account_id:)
+        follows.dataset
+          .where(follower_id: account_id, status: "approved")
+          .select_map(:followee_id)
+      end
+
+      private
+
+      def apply_cursor(scope, cursor)
+        return scope unless cursor
+
+        decoded = decode_cursor(cursor)
+        scope.where {
+          (created_at < decoded[:created_at]) |
+            ((created_at =~ decoded[:created_at]) & (id < decoded[:id]))
+        }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: 構文チェック**
+
+```bash
+ruby -c slices/social/repositories/follow_repository.rb
+```
+
+`Syntax OK` 必須。
+
+---
+
+## Task 5: `BlockRepository` (bidirectional + auto-unfollow transaction)
+
+**Files:** Create `services/monolith/workspace/slices/social/repositories/block_repository.rb`。
+
+- [ ] **Step 1: 実装**
+
+```ruby
+# frozen_string_literal: true
+
+require "concerns/cursor_pagination"
+
+module Social
+  module Repositories
+    # Symmetric block repository. blocker_id/blocked_id are both account_ids.
+    # Block creates a one-way row but the effect is bidirectional (enforced by callers reading
+    # bidirectionally_blocked_ids). Block transactionally removes any follows in both directions
+    # so the relationship is severed.
+    class BlockRepository < Social::DB::Repo
+      include Concerns::CursorPagination
+
+      # @param follow_repo [Social::Repositories::FollowRepository] injected for transactional unfollow
+      def initialize(follow_repo:)
+        super()
+        @follow_repo = follow_repo
+      end
+
+      # --- Mutations ----
+
+      def block(blocker_id:, blocked_id:)
+        rom.gateways[:default].transaction do
+          existing = blocks.where(blocker_id: blocker_id, blocked_id: blocked_id).one
+          unless existing
+            blocks.changeset(:create,
+              id: SecureRandom.uuid_v7,
+              blocker_id: blocker_id,
+              blocked_id: blocked_id
+            ).commit
+          end
+          @follow_repo.remove_bidirectional(account_a: blocker_id, account_b: blocked_id)
+        end
+        true
+      end
+
+      def unblock(blocker_id:, blocked_id:)
+        blocks.dataset.where(blocker_id: blocker_id, blocked_id: blocked_id).delete > 0
+      end
+
+      # --- Reads ----
+
+      def blocked?(blocker_id:, blocked_id:)
+        blocks.where(blocker_id: blocker_id, blocked_id: blocked_id).exist?
+      end
+
+      # account_id has blocked these ids
+      def blocked_ids(account_id:)
+        blocks.dataset.where(blocker_id: account_id).select_map(:blocked_id)
+      end
+
+      # These ids have blocked account_id
+      def blocker_ids(account_id:)
+        blocks.dataset.where(blocked_id: account_id).select_map(:blocker_id)
+      end
+
+      # Union: anyone in a bidirectional block with account_id
+      def bidirectionally_blocked_ids(account_id:)
+        (blocked_ids(account_id: account_id) + blocker_ids(account_id: account_id)).uniq
+      end
+
+      # cursor pagination for ListBlocked
+      def list_blocked(blocker_id:, limit: 20, cursor: nil)
+        scope = blocks.where(blocker_id: blocker_id)
+        scope = apply_cursor(scope, cursor)
+        scope.order { [created_at.desc, id.desc] }.limit(limit + 1).to_a
+      end
+
+      # @return [Hash{target_account_id (String) => Boolean}]
+      def status_batch(blocker_id:, blocked_ids:)
+        return {} if blocked_ids.nil? || blocked_ids.empty?
+
+        present = blocks.dataset
+          .where(blocker_id: blocker_id, blocked_id: blocked_ids)
+          .select_map(:blocked_id)
+          .map(&:to_s)
+        blocked_ids.each_with_object({}) { |id, h| h[id.to_s] = present.include?(id.to_s) }
+      end
+
+      private
+
+      def apply_cursor(scope, cursor)
+        return scope unless cursor
+
+        decoded = decode_cursor(cursor)
+        scope.where {
+          (created_at < decoded[:created_at]) |
+            ((created_at =~ decoded[:created_at]) & (id < decoded[:id]))
+        }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: 構文チェック**
+
+```bash
+ruby -c slices/social/repositories/block_repository.rb
+```
+
+`Syntax OK` 必須。
+
+---
+
+## Task 6: container resolve smoke + diff + commit
+
+- [ ] **Step 1: rspec 既存全 slice 維持確認**
+
+```bash
+cd services/monolith/workspace
+bundle exec rspec spec/slices/post 2>&1 | /usr/bin/tail -5
+bundle exec rspec spec/slices/feed 2>&1 | /usr/bin/tail -5
+bundle exec rspec spec/slices/relationship 2>&1 | /usr/bin/tail -5
+bundle exec rspec spec/slices/profile 2>&1 | /usr/bin/tail -5
+```
+
+期待: post 62/0、feed 4/0 (or dir absent)、relationship 31/0、profile 148/14 baseline 維持。
+
+- [ ] **Step 2: container resolve smoke**
+
+```bash
+bundle exec ruby -e '
+  require "hanami/prepare"
+  follow_repo = Social::Slice["repositories.follow_repository"]
+  puts "FollowRepository: #{follow_repo.class}"
+  puts "list_following empty: #{follow_repo.list_following(account_id: "00000000-0000-0000-0000-000000000000").inspect}"
+
+  block_repo = Social::Slice["repositories.block_repository"]
+  puts "BlockRepository: #{block_repo.class}"
+  puts "blocked_ids empty: #{block_repo.blocked_ids(account_id: "00000000-0000-0000-0000-000000000000").inspect}"
+' 2>&1 | /usr/bin/tail -10
+```
+
+期待:
+- `FollowRepository: Social::Repositories::FollowRepository`
+- `list_following empty: []`
+- `BlockRepository: Social::Repositories::BlockRepository`
+- `blocked_ids empty: []`
+
+container key auto-resolve 成功と migration 配備の動作確認を同時に。
+
+- [ ] **Step 3: diff stat 確認**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-social-s2-monolith
+/usr/bin/git diff --stat origin/main HEAD
+```
+
+期待: migration 1 + slice 7 file 新規 (db 2 + relations 2 + repositories 2 + + plan) + config/db/structure.sql 自動更新 (hanami migrate で生成) + plan = **9-10 files**。
+
+- [ ] **Step 4: コミット (signoff、Co-Authored-By 無し)**
+
+```bash
+cd /Users/takanokenichi/GitHub/panicboat/monorepo/.claude/worktrees/feat-social-s2-monolith
+/usr/bin/git add services/monolith/workspace docs/superpowers/plans/2026-06-15-social-s2a-schema-repo.md
+/usr/bin/git commit -s -m "feat(social): schema migration + slice base + relations + repositories"
+```
+
+push しない (controller 判断)。
+
+---
+
+## Deferred (本 S2a では実施しない)
+
+- use_cases (Follow / Unfollow / Approve / Reject / Cancel / ListFollowing / ListFollowers / ListPendingFollowRequests / GetFollowStatus / GetPendingFollowCount / Block / Unblock / ListBlocked / GetBlockStatus) → **S2b**
+- handlers (`Social::Grpc::FollowHandler` / `BlockHandler`) → **S2b**
+- cross-slice helpers (`viewer_can_see_post` / `filter_visible_posts`) → **S3**
+- frontend data 層 → **S4**
+- frontend UI → **S5**
+- cleanup of legacy `relationship` slice → cleanup フェーズ
+
+## Self-Review (作成者チェック済)
+
+- **Spec coverage (S2a 範囲)**: schema (`social.follows` / `social.blocks` with UNIQUE + indexes)、relations、`FollowRepository` / `BlockRepository` の主要メソッド全実装。Block の auto-unfollow transaction を repository で実装。
+- **Greenfield additive**: 既存 `relationship` slice / 他 slice 完全無改変。
+- **Placeholder 無し**: 全 task に完全コード。
+- **型 / 命名整合**: schema attribute `Types::String` + `Types::Time`、Sequel migration の `uuid` 型と整合。`follower_id` / `followee_id` / `blocker_id` / `blocked_id` 全て account_id (UUID string)。
+- **既存パターン踏襲**: relationship slice の `Relation < Monolith::DB::Relation` / `schema(:"namespace__table", as: :alias)` パターン完全同形。
+- **テスト方針**: rspec 既存 4 slice baseline 維持確認 + container smoke で resolve 成功と migration 配備を同時確認。新 unit spec は YAGNI で skip (S2b で integration spec、handler smoke で実機検証)。

--- a/services/monolith/workspace/config/db/migrate/20260615000000_create_social_schema.rb
+++ b/services/monolith/workspace/config/db/migrate/20260615000000_create_social_schema.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+ROM::SQL.migration do
+  up do
+    run "CREATE SCHEMA IF NOT EXISTS social"
+
+    create_table :"social__follows" do
+      column :id, :uuid, null: false
+      column :follower_id, :uuid, null: false
+      column :followee_id, :uuid, null: false
+      column :status, :text, null: false, default: "approved"  # "pending" | "approved"
+      column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+      column :updated_at, :timestamptz, null: false, default: Sequel.lit("now()")
+
+      primary_key [:id]
+      unique [:follower_id, :followee_id]
+      index :follower_id
+      index :followee_id
+      index [:followee_id, :status]
+    end
+
+    create_table :"social__blocks" do
+      column :id, :uuid, null: false
+      column :blocker_id, :uuid, null: false
+      column :blocked_id, :uuid, null: false
+      column :created_at, :timestamptz, null: false, default: Sequel.lit("now()")
+
+      primary_key [:id]
+      unique [:blocker_id, :blocked_id]
+      index :blocker_id
+      index :blocked_id
+    end
+  end
+
+  down do
+    drop_table :"social__blocks"
+    drop_table :"social__follows"
+    run "DROP SCHEMA IF EXISTS social CASCADE"
+  end
+end

--- a/services/monolith/workspace/config/db/structure.sql
+++ b/services/monolith/workspace/config/db/structure.sql
@@ -59,6 +59,13 @@ CREATE SCHEMA relationship;
 
 
 --
+-- Name: social; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA social;
+
+
+--
 -- Name: trust; Type: SCHEMA; Schema: -; Owner: -
 --
 
@@ -437,6 +444,32 @@ CREATE TABLE relationship.follows (
 
 
 --
+-- Name: blocks; Type: TABLE; Schema: social; Owner: -
+--
+
+CREATE TABLE social.blocks (
+    id uuid NOT NULL,
+    blocker_id uuid NOT NULL,
+    blocked_id uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: follows; Type: TABLE; Schema: social; Owner: -
+--
+
+CREATE TABLE social.follows (
+    id uuid NOT NULL,
+    follower_id uuid NOT NULL,
+    followee_id uuid NOT NULL,
+    status text DEFAULT 'approved'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
 -- Name: review_media; Type: TABLE; Schema: trust; Owner: -
 --
 
@@ -730,6 +763,38 @@ ALTER TABLE ONLY relationship.follows
 
 ALTER TABLE ONLY relationship.follows
     ADD CONSTRAINT follows_cast_user_id_guest_user_id_key UNIQUE (cast_user_id, guest_user_id);
+
+
+--
+-- Name: blocks blocks_blocker_id_blocked_id_key; Type: CONSTRAINT; Schema: social; Owner: -
+--
+
+ALTER TABLE ONLY social.blocks
+    ADD CONSTRAINT blocks_blocker_id_blocked_id_key UNIQUE (blocker_id, blocked_id);
+
+
+--
+-- Name: blocks blocks_pkey; Type: CONSTRAINT; Schema: social; Owner: -
+--
+
+ALTER TABLE ONLY social.blocks
+    ADD CONSTRAINT blocks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: follows follows_follower_id_followee_id_key; Type: CONSTRAINT; Schema: social; Owner: -
+--
+
+ALTER TABLE ONLY social.follows
+    ADD CONSTRAINT follows_follower_id_followee_id_key UNIQUE (follower_id, followee_id);
+
+
+--
+-- Name: follows follows_pkey; Type: CONSTRAINT; Schema: social; Owner: -
+--
+
+ALTER TABLE ONLY social.follows
+    ADD CONSTRAINT follows_pkey PRIMARY KEY (id);
 
 
 --
@@ -1052,6 +1117,41 @@ CREATE INDEX social_cast_follows_status_index ON relationship.follows USING btre
 
 
 --
+-- Name: social_blocks_blocked_id_index; Type: INDEX; Schema: social; Owner: -
+--
+
+CREATE INDEX social_blocks_blocked_id_index ON social.blocks USING btree (blocked_id);
+
+
+--
+-- Name: social_blocks_blocker_id_index; Type: INDEX; Schema: social; Owner: -
+--
+
+CREATE INDEX social_blocks_blocker_id_index ON social.blocks USING btree (blocker_id);
+
+
+--
+-- Name: social_follows_followee_id_index; Type: INDEX; Schema: social; Owner: -
+--
+
+CREATE INDEX social_follows_followee_id_index ON social.follows USING btree (followee_id);
+
+
+--
+-- Name: social_follows_followee_id_status_index; Type: INDEX; Schema: social; Owner: -
+--
+
+CREATE INDEX social_follows_followee_id_status_index ON social.follows USING btree (followee_id, status);
+
+
+--
+-- Name: social_follows_follower_id_index; Type: INDEX; Schema: social; Owner: -
+--
+
+CREATE INDEX social_follows_follower_id_index ON social.follows USING btree (follower_id);
+
+
+--
 -- Name: trust_review_media_media_id_index; Type: INDEX; Schema: trust; Owner: -
 --
 
@@ -1303,4 +1403,5 @@ INSERT INTO schema_migrations (filename) VALUES
 ('20260604000002_create_profiles.rb'),
 ('20260604000003_create_profile_areas.rb'),
 ('20260607000001_add_author_id_to_posts.rb'),
-('20260607000002_add_account_id_to_likes.rb');
+('20260607000002_add_account_id_to_likes.rb'),
+('20260615000000_create_social_schema.rb');

--- a/services/monolith/workspace/slices/social/db/relation.rb
+++ b/services/monolith/workspace/slices/social/db/relation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Social
+  module DB
+    class Relation < Monolith::DB::Relation
+    end
+  end
+end

--- a/services/monolith/workspace/slices/social/db/repo.rb
+++ b/services/monolith/workspace/slices/social/db/repo.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Social
+  module DB
+    class Repo < Monolith::DB::Repo
+    end
+  end
+end

--- a/services/monolith/workspace/slices/social/relations/blocks.rb
+++ b/services/monolith/workspace/slices/social/relations/blocks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Social
+  module Relations
+    class Blocks < Social::DB::Relation
+      schema(:"social__blocks", as: :blocks, infer: false) do
+        attribute :id, Types::String
+        attribute :blocker_id, Types::String
+        attribute :blocked_id, Types::String
+        attribute :created_at, Types::Time
+
+        primary_key :id
+      end
+    end
+  end
+end

--- a/services/monolith/workspace/slices/social/relations/follows.rb
+++ b/services/monolith/workspace/slices/social/relations/follows.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Social
+  module Relations
+    class Follows < Social::DB::Relation
+      schema(:"social__follows", as: :follows, infer: false) do
+        attribute :id, Types::String
+        attribute :follower_id, Types::String
+        attribute :followee_id, Types::String
+        attribute :status, Types::String
+        attribute :created_at, Types::Time
+        attribute :updated_at, Types::Time
+
+        primary_key :id
+      end
+    end
+  end
+end

--- a/services/monolith/workspace/slices/social/repositories/block_repository.rb
+++ b/services/monolith/workspace/slices/social/repositories/block_repository.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "concerns/cursor_pagination"
+
+module Social
+  module Repositories
+    # Symmetric block repository. blocker_id/blocked_id are both account_ids.
+    # Block creates a one-way row but the effect is bidirectional (enforced by callers reading
+    # bidirectionally_blocked_ids). Block transactionally removes any follows in both directions
+    # so the relationship is severed.
+    class BlockRepository < Social::DB::Repo
+      include Concerns::CursorPagination
+      include Social::Deps[follow_repo: "repositories.follow_repository"]
+
+      # --- Mutations ----
+
+      def block(blocker_id:, blocked_id:)
+        rom.gateways[:default].transaction do
+          existing = blocks.where(blocker_id: blocker_id, blocked_id: blocked_id).one
+          unless existing
+            blocks.changeset(:create,
+              id: SecureRandom.uuid_v7,
+              blocker_id: blocker_id,
+              blocked_id: blocked_id
+            ).commit
+          end
+          follow_repo.remove_bidirectional(account_a: blocker_id, account_b: blocked_id)
+        end
+        true
+      end
+
+      def unblock(blocker_id:, blocked_id:)
+        blocks.dataset.where(blocker_id: blocker_id, blocked_id: blocked_id).delete > 0
+      end
+
+      # --- Reads ----
+
+      def blocked?(blocker_id:, blocked_id:)
+        blocks.where(blocker_id: blocker_id, blocked_id: blocked_id).exist?
+      end
+
+      # account_id has blocked these ids
+      def blocked_ids(account_id:)
+        blocks.dataset.where(blocker_id: account_id).select_map(:blocked_id)
+      end
+
+      # These ids have blocked account_id
+      def blocker_ids(account_id:)
+        blocks.dataset.where(blocked_id: account_id).select_map(:blocker_id)
+      end
+
+      # Union: anyone in a bidirectional block with account_id
+      def bidirectionally_blocked_ids(account_id:)
+        (blocked_ids(account_id: account_id) + blocker_ids(account_id: account_id)).uniq
+      end
+
+      # cursor pagination for ListBlocked
+      def list_blocked(blocker_id:, limit: 20, cursor: nil)
+        scope = blocks.where(blocker_id: blocker_id)
+        scope = apply_cursor(scope, cursor)
+        scope.order { [created_at.desc, id.desc] }.limit(limit + 1).to_a
+      end
+
+      # @return [Hash{target_account_id (String) => Boolean}]
+      def status_batch(blocker_id:, blocked_ids:)
+        return {} if blocked_ids.nil? || blocked_ids.empty?
+
+        present = blocks.dataset
+          .where(blocker_id: blocker_id, blocked_id: blocked_ids)
+          .select_map(:blocked_id)
+          .map(&:to_s)
+        blocked_ids.each_with_object({}) { |id, h| h[id.to_s] = present.include?(id.to_s) }
+      end
+
+      private
+
+      def apply_cursor(scope, cursor)
+        return scope unless cursor
+
+        decoded = decode_cursor(cursor)
+        scope.where {
+          (created_at < decoded[:created_at]) |
+            ((created_at =~ decoded[:created_at]) & (id < decoded[:id]))
+        }
+      end
+    end
+  end
+end

--- a/services/monolith/workspace/slices/social/repositories/follow_repository.rb
+++ b/services/monolith/workspace/slices/social/repositories/follow_repository.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "concerns/cursor_pagination"
+
+module Social
+  module Repositories
+    # Symmetric follow repository. follower_id/followee_id are both account_ids.
+    # status is "approved" (immediate, default for public targets) or "pending" (private targets).
+    class FollowRepository < Social::DB::Repo
+      include Concerns::CursorPagination
+
+      # --- Mutations ----
+
+      # Insert or no-op. Returns the resulting status (existing or new).
+      # @return [Hash{success: Boolean, status: String, reason: Symbol?}]
+      def follow(follower_id:, followee_id:, status:)
+        existing = follows.where(follower_id: follower_id, followee_id: followee_id).one
+        return { success: false, status: existing.status, reason: :already_exists } if existing
+
+        follows.changeset(:create,
+          id: SecureRandom.uuid_v7,
+          follower_id: follower_id,
+          followee_id: followee_id,
+          status: status,
+          updated_at: Time.now
+        ).commit
+        { success: true, status: status }
+      end
+
+      def unfollow(follower_id:, followee_id:)
+        follows.dataset.where(follower_id: follower_id, followee_id: followee_id).delete > 0
+      end
+
+      def update_status(follower_id:, followee_id:, status:)
+        updated = follows.dataset
+          .where(follower_id: follower_id, followee_id: followee_id)
+          .update(status: status, updated_at: Time.now)
+        updated > 0
+      end
+
+      # Delete both directions (used by Block transaction in BlockRepository).
+      def remove_bidirectional(account_a:, account_b:)
+        follows.dataset
+          .where(
+            Sequel.|(
+              { follower_id: account_a, followee_id: account_b },
+              { follower_id: account_b, followee_id: account_a }
+            )
+          )
+          .delete
+      end
+
+      # --- Reads ----
+
+      def find(follower_id:, followee_id:)
+        follows.where(follower_id: follower_id, followee_id: followee_id).one
+      end
+
+      def list_following(account_id:, status: "approved", limit: 20, cursor: nil)
+        scope = follows.where(follower_id: account_id, status: status)
+        scope = apply_cursor(scope, cursor)
+        scope.order { [created_at.desc, id.desc] }.limit(limit + 1).to_a
+      end
+
+      def list_followers(account_id:, status: "approved", limit: 20, cursor: nil)
+        scope = follows.where(followee_id: account_id, status: status)
+        scope = apply_cursor(scope, cursor)
+        scope.order { [created_at.desc, id.desc] }.limit(limit + 1).to_a
+      end
+
+      def list_pending_to(account_id:, limit: 20, cursor: nil)
+        list_followers(account_id: account_id, status: "pending", limit: limit, cursor: cursor)
+      end
+
+      def count_pending_to(account_id:)
+        follows.where(followee_id: account_id, status: "pending").count
+      end
+
+      # @return [Hash{target_account_id (String) => status (String)}], missing keys = no row
+      def status_batch(follower_id:, followee_ids:)
+        return {} if followee_ids.nil? || followee_ids.empty?
+
+        rows = follows.dataset
+          .where(follower_id: follower_id, followee_id: followee_ids)
+          .select_map([:followee_id, :status])
+        rows.each_with_object({}) { |(target, status), h| h[target.to_s] = status }
+      end
+
+      # Used by Feed FOLLOWING tab (already exposed since F3).
+      def following_account_ids(account_id:)
+        follows.dataset
+          .where(follower_id: account_id, status: "approved")
+          .select_map(:followee_id)
+      end
+
+      private
+
+      def apply_cursor(scope, cursor)
+        return scope unless cursor
+
+        decoded = decode_cursor(cursor)
+        scope.where {
+          (created_at < decoded[:created_at]) |
+            ((created_at =~ decoded[:created_at]) & (id < decoded[:id]))
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Social slice S2a = monolith `slices/social/` 配下に schema migration + slice base + 2 relations + 2 repositories を greenfield 配置。use_cases / handlers は **S2b** で。

旧 `social` schema は 2026-02-16 migration で空 (旧 social.* テーブルは `relationship` / `post` schema に移動済) → `CREATE SCHEMA IF NOT EXISTS social` で衝突無し。

## Commit

- `adc2ccd6` 9 files (migration + 6 slice file + structure.sql 自動更新 + plan)

### Added

- migration `20260615000000_create_social_schema.rb`: `social` schema + `follows(follower_id, followee_id, status, created_at, updated_at)` + `blocks(blocker_id, blocked_id, created_at)`、UNIQUE + index 設定
- `slices/social/db/{relation,repo}.rb` (base)
- `slices/social/relations/{follows,blocks}.rb`
- `slices/social/repositories/follow_repository.rb` (mutations + reads + status_batch + following_account_ids)
- `slices/social/repositories/block_repository.rb` (block transaction で follow auto-unfollow + bidirectional reads + status_batch)

## Plan からの調整 1 件

- **BlockRepository**: plan は `initialize(follow_repo:)` だったが、Hanami の Repo auto-resolve は `**kwargs` を expect しないため `include Social::Deps[follow_repo: "repositories.follow_repository"]` パターンに変更。挙動 (block transaction で follow 双方向削除) は同一、container auto-resolve OK。

## Verification

- [x] `hanami db migrate` 緑 (monolith + monolith_test 両 DB 配備)
- [x] `psql \d social.follows` 構造確認 (unique + index 配備済)
- [x] rspec 4 slice baseline 完全維持 (post 62/0, feed dir 不在, relationship 31/0, profile 148/14)
- [x] container resolve smoke: `Social::Slice["repositories.{follow,block}_repository"]` 双方 auto-resolve OK、empty query 動作確認

## Next increments

| step | scope | status |
|---|---|---|
| S0 | design spec | merged (#676) |
| S1 | proto greenfield | merged (#676) |
| **S2a 本 PR** | schema + slice base + relations + repositories | |
| S2b | use_cases (14) + handlers (2) | next |
| S3 | cross-slice follow-gate | |
| S4 | frontend data 層 | |
| S5 | frontend UI | |
| cleanup | 旧 relationship slice 一括 drop | |
