### PR TITLE
fix(post): resolve Concerns::CursorPagination via top-level path to avoid Post::Concerns collision

### DIFF
--- a/services/monolith/workspace/slices/post/grpc/handler.rb
+++ b/services/monolith/workspace/slices/post/grpc/handler.rb
@@ -15,7 +15,7 @@ module Post
     class Handler < ::Gruf::Controllers::Base
       include ::GRPC::GenericService
       include ::Grpc::Authenticatable
-      include Concerns::CursorPagination
+      include ::Concerns::CursorPagination
 
       include Post::Deps[
         post_repo: "repositories.post_repository",

--- a/services/monolith/workspace/slices/post/use_cases/comments/list_comments.rb
+++ b/services/monolith/workspace/slices/post/use_cases/comments/list_comments.rb
@@ -7,7 +7,7 @@ module Post
     module Comments
       class ListComments
         include Post::Deps[comment_repo: "repositories.comment_repository"]
-        include Concerns::CursorPagination
+        include ::Concerns::CursorPagination
         include Post::Concerns::ProfileAuthorResolvable
 
         MAX_LIMIT = 50

--- a/services/monolith/workspace/slices/post/use_cases/comments/list_replies.rb
+++ b/services/monolith/workspace/slices/post/use_cases/comments/list_replies.rb
@@ -7,7 +7,7 @@ module Post
     module Comments
       class ListReplies
         include Post::Deps[comment_repo: "repositories.comment_repository"]
-        include Concerns::CursorPagination
+        include ::Concerns::CursorPagination
         include Post::Concerns::ProfileAuthorResolvable
 
         MAX_LIMIT = 50


### PR DESCRIPTION
## Summary

\`bin/grpc\` production boot で発生していた \`uninitialized constant Post::Concerns::CursorPagination (NameError)\` を 3 行の絶対パス修正で解消。

### Root cause

Post slice には \`slices/post/concerns/profile_author_resolvable.rb\` が存在し、Zeitwerk が \`Post::Concerns\` 名前空間を eager load する。production mode の \`bin/grpc\` で:

\`\`\`ruby
module Post::Grpc::Handler
  include Concerns::CursorPagination  # ← Ruby が Post::Concerns::CursorPagination として解決
end
\`\`\`

Ruby の定数解決が \`Post::Concerns\` を見つけ、その配下の \`CursorPagination\` を autoload しようとして失敗。トップレベルの \`::Concerns::CursorPagination\` (lib/concerns/cursor_pagination.rb で定義) にフォールバックする前に NameError。

### Fix

\`include Concerns::CursorPagination\` → \`include ::Concerns::CursorPagination\` で絶対パス指定。affected 3 files:

- \`slices/post/grpc/handler.rb:18\`
- \`slices/post/use_cases/comments/list_comments.rb:10\`
- \`slices/post/use_cases/comments/list_replies.rb:10\`

他 slice (social / feed / trust / profile 等) は \`Concerns\` 同名 sub-namespace が無いため fallback で正常解決、本 fix 対象外。

### Verification

- \`bin/grpc\` boot 成功確認、Gruf services リストに 14 service が全て登録 (\`Notifications::V1::NotificationService::Service\` 含む N2 #693 の本来期待値)
- rspec post 62/0 + profile 153/14 baseline 完全維持
- ruby -c 3 file OK

### Notes

S2b の hidden bug (#684 で fix) に続く \`bin/grpc\` 関連の隠れバグ第 2 弾。N2 (#693) の subagent 報告で発覚していた pre-existing issue を本 PR で清算。