### PR TITLE
feat(post): composer modal wired to FAB (savePost + SWR refresh)

### DIFF
--- a/services/frontend/workspace/src/components/shell/ComposerFAB.tsx
+++ b/services/frontend/workspace/src/components/shell/ComposerFAB.tsx
@@ -1,14 +1,22 @@
 "use client";
 
+import { useState } from "react";
+import { PostComposerModal } from "@/modules/post/components/PostComposerModal";
+
 export function ComposerFAB() {
+  const [open, setOpen] = useState(false);
+
   return (
-    <button
-      type="button"
-      onClick={() => alert("投稿機能は近日対応です")}
-      className="fixed bottom-20 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-brand text-2xl text-white shadow-brand-glow active:scale-95 md:hidden"
-      aria-label="投稿を作成"
-    >
-      ＋
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-20 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-brand text-2xl text-white shadow-brand-glow active:scale-95 md:hidden"
+        aria-label="投稿を作成"
+      >
+        ＋
+      </button>
+      <PostComposerModal open={open} onClose={() => setOpen(false)} />
+    </>
   );
 }

--- a/services/frontend/workspace/src/modules/post/components/PostComposerModal.tsx
+++ b/services/frontend/workspace/src/modules/post/components/PostComposerModal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useSWRConfig } from "swr";
+import { authFetch } from "@/lib/auth";
+import { PostComposer } from "./PostComposer";
+import type { SavePostPayload } from "@/modules/post/lib/post-view";
+
+interface PostComposerModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function PostComposerModal({ open, onClose }: PostComposerModalProps) {
+  const { mutate } = useSWRConfig();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const handleSubmit = useCallback(async (payload: SavePostPayload) => {
+    await authFetch("/api/posts", { method: "POST", body: payload });
+    // Invalidate any feed/posts list cache so the new post appears on next navigation/refresh.
+    mutate((key) => typeof key === "string" && (key.startsWith("/api/posts") || key.startsWith("/api/feed")), undefined, { revalidate: true });
+    onClose();
+  }, [mutate, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 bg-black/60"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="投稿を作成"
+        className="fixed left-1/2 top-1/2 z-50 w-[92vw] max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-lg bg-bg p-4 shadow-2xl"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-bold text-text-primary">投稿を作成</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-1 text-text-secondary hover:bg-bg-secondary hover:text-text-primary"
+            aria-label="閉じる"
+          >
+            ✕
+          </button>
+        </div>
+        <PostComposer onSubmit={handleSubmit} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 1b-A (#699) で alert placeholder のまま放置されていた右下 corner FAB を、実 modal + 既存 \`PostComposer\` form + \`POST /api/posts\` で実機能化。

### 内訳

- **新規**: \`src/modules/post/components/PostComposerModal.tsx\` (overlay + dialog wrapper、ESC で close、submit 後に SWR \`/api/posts\` / \`/api/feed\` cache を invalidate)
- **修正**: \`src/components/shell/ComposerFAB.tsx\` (alert → \`useState\` + \`PostComposerModal\` 開閉)

### 既存活用

- \`PostComposer\` (Phase 1a-生まれ) の form (textarea + visibility toggle + char counter + submit) はそのまま再利用
- \`POST /api/posts\` BFF (\`postClient.savePost\` 呼出) もそのまま再利用
- 新たな BFF / hook 追加なし、UI wrapper の 2 file のみ

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)
- SWR mutate で \`/api/posts*\` + \`/api/feed*\` 系の全 cache key を invalidate、submit 後に Home feed 等が新 post を含めて再 fetch される

## Notes

- Modal は \`md:hidden\` の FAB 経由でのみ開く (desktop は FAB 自体が非表示)。desktop 用の compose entry は Phase 2 以降に desktop 3-col layout を構築する際に追加余地。
- composer 内の media upload は spec で defer 済、本 PR でも text + visibility のみ対応 (既存 \`PostComposer\` の制約に従う)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Post composer now opens in a dedicated modal dialog with improved usability.
  * Modal supports multiple dismiss options: Escape key, overlay click, and close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->