### PR TITLE
feat(post): comment list on /posts/[id] (P5 deferred resolved)

### DIFF
--- a/services/frontend/workspace/src/app/api/posts/[id]/comments/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/[id]/comments/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { commentClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { mapCommentsListResponse } from "@/modules/post/lib/comment-mappers";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const limit = Number(req.nextUrl.searchParams.get("limit") || "20");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+
+    const res = await commentClient.listComments({ postId: id, limit, cursor }, { headers });
+    return NextResponse.json(mapCommentsListResponse(res));
+  } catch (error: unknown) {
+    return handleApiError(error, "ListComments");
+  }
+}

--- a/services/frontend/workspace/src/app/posts/[id]/page.tsx
+++ b/services/frontend/workspace/src/app/posts/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams } from "next/navigation";
 import { usePost } from "@/modules/post/hooks/usePost";
 import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
+import { CommentList } from "@/modules/post/components/CommentList";
 
 export default function PostDetailPage() {
   const params = useParams<{ id: string }>();
@@ -19,9 +20,12 @@ export default function PostDetailPage() {
   return (
     <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
       <PostCardBinding post={post} />
-      <p className="px-4 py-6 text-sm text-text-muted">
-        コメント（{post.commentsCount} 件）の表示はコメントスライス UI 更新後に対応。
-      </p>
+      <section className="border-t border-divider">
+        <h2 className="px-4 py-3 text-sm font-bold text-text-secondary">
+          コメント（{post.commentsCount} 件）
+        </h2>
+        <CommentList postId={post.id} />
+      </section>
     </main>
   );
 }

--- a/services/frontend/workspace/src/modules/post/components/CommentList.tsx
+++ b/services/frontend/workspace/src/modules/post/components/CommentList.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Avatar } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { formatTimeAgo } from "@/lib/utils/date";
+import { useComments } from "@/modules/post/hooks/useComments";
+
+interface CommentListProps {
+  postId: string;
+}
+
+export function CommentList({ postId }: CommentListProps) {
+  const { comments, hasMore, loading, error, loadMore } = useComments(postId);
+
+  if (loading && comments.length === 0) {
+    return <p className="px-4 py-4 text-text-secondary">読み込み中…</p>;
+  }
+  if (error) {
+    return <p className="px-4 py-4 text-text-secondary">読み込みに失敗しました</p>;
+  }
+  if (!loading && comments.length === 0) {
+    return <p className="px-4 py-4 text-text-secondary">まだコメントはありません</p>;
+  }
+
+  return (
+    <div>
+      {comments.map((c) => (
+        <article key={c.id} className="flex gap-3 border-b border-divider px-4 py-3">
+          <Avatar
+            src={c.author?.imageUrl || undefined}
+            fallback={(c.author?.name || "?").slice(0, 1)}
+            size="sm"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1 text-sm">
+              <span className="font-bold text-text-primary">{c.author?.name || "—"}</span>
+              <span className="text-text-muted">· {c.createdAt ? formatTimeAgo(c.createdAt) : ""}</span>
+            </div>
+            <p className="mt-1 whitespace-pre-wrap text-text-primary">{c.content}</p>
+            {c.repliesCount > 0 && (
+              <p className="mt-2 text-xs text-text-secondary">{c.repliesCount} 件の返信</p>
+            )}
+          </div>
+        </article>
+      ))}
+      {hasMore && (
+        <div className="flex justify-center px-4 py-4">
+          <Button variant="secondary" size="md" onClick={() => loadMore()} disabled={loading}>
+            もっと見る
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useComments.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useComments.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import useSWRInfinite from "swr/infinite";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PaginatedCommentsResponse } from "@/modules/post/lib/comment-view";
+
+export function useComments(postId: string | null | undefined) {
+  const token = getAuthToken();
+
+  const getKey = (pageIndex: number, prev: PaginatedCommentsResponse | null): string | null => {
+    if (!token || !postId) return null;
+    if (prev && !prev.hasMore) return null;
+    const cursorQs = pageIndex === 0 ? "" : `?cursor=${encodeURIComponent(prev?.nextCursor || "")}`;
+    return `/api/posts/${encodeURIComponent(postId)}/comments${cursorQs}`;
+  };
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<PaginatedCommentsResponse>(getKey, fetcher, { revalidateOnFocus: false });
+
+  const pages = data || [];
+  const comments = pages.flatMap((p) => p.comments || []);
+  const hasMore = pages.length > 0 ? !!pages[pages.length - 1].hasMore : false;
+
+  return {
+    comments,
+    hasMore,
+    loading: isLoading || isValidating,
+    error,
+    loadMore: () => setSize(size + 1),
+    refresh: () => mutate(),
+  };
+}

--- a/services/frontend/workspace/src/modules/post/lib/comment-mappers.ts
+++ b/services/frontend/workspace/src/modules/post/lib/comment-mappers.ts
@@ -1,0 +1,36 @@
+import type { Comment, CommentAuthor, ListCommentsResponse } from "@/stub/post/v1/comment_service_pb";
+import type {
+  CommentAuthorView,
+  CommentView,
+  PaginatedCommentsResponse,
+} from "./comment-view";
+
+function mapAuthor(a: CommentAuthor | undefined): CommentAuthorView | null {
+  if (!a || !a.userId) return null;
+  return {
+    userId: a.userId,
+    name: a.name,
+    imageUrl: a.imageUrl,
+  };
+}
+
+export function mapCommentToView(c: Comment): CommentView {
+  return {
+    id: c.id,
+    postId: c.postId,
+    parentId: c.parentId || null,
+    userId: c.userId,
+    content: c.content,
+    createdAt: c.createdAt,
+    author: mapAuthor(c.author),
+    repliesCount: c.repliesCount,
+  };
+}
+
+export function mapCommentsListResponse(res: ListCommentsResponse): PaginatedCommentsResponse {
+  return {
+    comments: (res.comments || []).map(mapCommentToView),
+    nextCursor: res.nextCursor || "",
+    hasMore: !!res.hasMore,
+  };
+}

--- a/services/frontend/workspace/src/modules/post/lib/comment-view.ts
+++ b/services/frontend/workspace/src/modules/post/lib/comment-view.ts
@@ -1,0 +1,22 @@
+export interface CommentAuthorView {
+  userId: string;
+  name: string;
+  imageUrl: string;
+}
+
+export interface CommentView {
+  id: string;
+  postId: string;
+  parentId: string | null;
+  userId: string;
+  content: string;
+  createdAt: string;
+  author: CommentAuthorView | null;
+  repliesCount: number;
+}
+
+export interface PaginatedCommentsResponse {
+  comments: CommentView[];
+  nextCursor: string;
+  hasMore: boolean;
+}


### PR DESCRIPTION
## Summary

\`/posts/[id]\` page で「コメント（N 件）の表示はコメントスライス UI 更新後に対応。」と placeholder のまま残されていた P5 deferred を解消。\`post.v1.CommentService.ListComments\` を frontend に届け、コメント一覧 + cursor "もっと見る" + empty/loading/error 表示を実装。

### 内訳

- **types**: \`CommentView\` / \`CommentAuthorView\` / \`PaginatedCommentsResponse\`
- **mappers**: \`mapCommentToView\` / \`mapCommentsListResponse\` (proto Comment → view)
- **BFF**: \`GET /api/posts/[id]/comments\` (cursor pagination、既存 \`commentClient.listComments\` 活用)
- **hook**: \`useComments(postId)\` (\`useSWRInfinite\` + cursor + loadMore + refresh)
- **component**: \`CommentList.tsx\` (avatar + name + 時刻 + 本文 + replies count + "もっと見る")
- **/posts/[id] 拡張**: placeholder 削除、\`<section>\` で「コメント（N 件）」ヘッダ + \`<CommentList postId={post.id} />\`

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑、新 \`/api/posts/[id]/comments\` BFF が build 出力に登場
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)

## Notes

- 本 PR は **読み取り (List) のみ**。Add / Delete / Replies expansion は別 PR で段階追加 (Posts polish B / C)。
- 既存 \`commentClient\` (\`src/lib/grpc.ts\`) を再利用、新 client 追加なし。

## Decomposition

- **Polish A (本 PR)**: コメント list 表示のみ
- Polish B: コメント add (POST BFF + CommentComposer)
- Polish C: delete + replies (DELETE BFF + ListReplies + 展開 UI)