### PR TITLE
feat(post): comment composer on /posts/[id] (add via AddComment RPC)

### DIFF
--- a/services/frontend/workspace/src/app/api/posts/[id]/comments/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/[id]/comments/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { commentClient } from "@/lib/grpc";
 import { buildGrpcHeaders } from "@/lib/request";
 import { requireAuth, handleApiError } from "@/lib/api-helpers";
-import { mapCommentsListResponse } from "@/modules/post/lib/comment-mappers";
+import { mapCommentToView, mapCommentsListResponse } from "@/modules/post/lib/comment-mappers";
 
 export async function GET(
   req: NextRequest,
@@ -21,5 +21,32 @@ export async function GET(
     return NextResponse.json(mapCommentsListResponse(res));
   } catch (error: unknown) {
     return handleApiError(error, "ListComments");
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const body = await req.json();
+    const content = typeof body?.content === "string" ? body.content : "";
+    const parentId = typeof body?.parentId === "string" ? body.parentId : "";
+
+    const res = await commentClient.addComment(
+      { postId: id, content, parentId, media: [] },
+      { headers }
+    );
+    return NextResponse.json({
+      comment: res.comment ? mapCommentToView(res.comment) : null,
+      commentsCount: res.commentsCount,
+    });
+  } catch (error: unknown) {
+    return handleApiError(error, "AddComment");
   }
 }

--- a/services/frontend/workspace/src/app/posts/[id]/page.tsx
+++ b/services/frontend/workspace/src/app/posts/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { usePost } from "@/modules/post/hooks/usePost";
 import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
 import { CommentList } from "@/modules/post/components/CommentList";
+import { CommentComposer } from "@/modules/post/components/CommentComposer";
 
 export default function PostDetailPage() {
   const params = useParams<{ id: string }>();
@@ -24,6 +25,7 @@ export default function PostDetailPage() {
         <h2 className="px-4 py-3 text-sm font-bold text-text-secondary">
           コメント（{post.commentsCount} 件）
         </h2>
+        <CommentComposer postId={post.id} />
         <CommentList postId={post.id} />
       </section>
     </main>

--- a/services/frontend/workspace/src/modules/post/components/CommentComposer.tsx
+++ b/services/frontend/workspace/src/modules/post/components/CommentComposer.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useAddComment } from "@/modules/post/hooks/useAddComment";
+
+interface CommentComposerProps {
+  postId: string;
+}
+
+const MAX_LENGTH = 1000;
+
+export function CommentComposer({ postId }: CommentComposerProps) {
+  const [content, setContent] = useState("");
+  const { addComment, submitting, error } = useAddComment(postId);
+
+  const trimmed = content.trim();
+  const overLimit = content.length > MAX_LENGTH;
+  const canSubmit = !submitting && trimmed.length > 0 && !overLimit;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!canSubmit) return;
+      try {
+        await addComment(content);
+        setContent("");
+      } catch {
+        // error は hook 内 state に立つ、UI で表示
+      }
+    },
+    [canSubmit, content, addComment]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="border-b border-divider px-4 py-3">
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="コメントを書く"
+        rows={2}
+        aria-label="コメント内容"
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <span
+          className={`text-xs ${overLimit ? "text-error" : "text-text-muted"}`}
+          aria-live="polite"
+        >
+          {content.length}/{MAX_LENGTH}
+        </span>
+        <Button type="submit" variant="primary" size="sm" disabled={!canSubmit}>
+          {submitting ? "送信中…" : "送信"}
+        </Button>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm text-error" role="alert">
+          コメント送信に失敗しました
+        </p>
+      )}
+    </form>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useAddComment.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useAddComment.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useSWRConfig } from "swr";
+import { authFetch } from "@/lib/auth";
+
+export function useAddComment(postId: string | null | undefined) {
+  const { mutate } = useSWRConfig();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const addComment = useCallback(
+    async (content: string) => {
+      if (!postId) return;
+      const trimmed = content.trim();
+      if (trimmed.length === 0) return;
+
+      setSubmitting(true);
+      setError(null);
+      try {
+        await authFetch(`/api/posts/${encodeURIComponent(postId)}/comments`, {
+          method: "POST",
+          body: { content: trimmed },
+        });
+        // Refresh: comment list (useSWRInfinite cache keys start with this path) + post detail (commentsCount)
+        mutate(
+          (key) =>
+            typeof key === "string" &&
+            key.startsWith(`/api/posts/${encodeURIComponent(postId)}/comments`)
+        );
+        mutate(`/api/posts/${encodeURIComponent(postId)}`);
+      } catch (e) {
+        setError(e as Error);
+        throw e;
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [postId, mutate]
+  );
+
+  return { addComment, submitting, error };
+}


### PR DESCRIPTION
## Summary

Posts polish B: \`/posts/[id]\` page にコメント投稿 composer を追加。\`post.v1.CommentService.AddComment\` を frontend に届け、テキストコメントを投稿できる状態に。Polish A (#704) の list 表示の直上に composer 配置。

### 内訳

- **BFF**: \`POST /api/posts/[id]/comments\` を既存 GET route に追加 (body \`{ content, parentId? }\`、media は今回スコープ外で空配列固定)
- **hook**: \`useAddComment(postId)\` (submit + SWR mutate で list + post detail invalidate)
- **component**: \`CommentComposer.tsx\` (textarea + char counter + submit button、PostComposer と同形 UI)
- **/posts/[id] 拡張**: CommentList の上に CommentComposer 配置、投稿後に list + commentsCount が自動再 fetch

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)

## Notes

- text only、media upload は今回 scope 外 (PostComposer 同様)
- reply (parent_id 指定) は今回未対応、Polish C で reply 展開 UI と一緒に追加予定
- 既存 \`commentClient\` 再利用、新 client / 新 module 追加なし

## Decomposition

- Polish A #704 (list)
- **Polish B (本 PR)** (add)
- Polish C: delete + replies expansion (DELETE BFF + ListReplies + 展開 UI)