### PR TITLE
feat(post): comment delete + replies expansion on /posts/[id]

### DIFF
--- a/services/frontend/workspace/src/app/api/posts/[id]/comments/[commentId]/replies/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/[id]/comments/[commentId]/replies/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { commentClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { mapCommentToView } from "@/modules/post/lib/comment-mappers";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { commentId } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const limit = Number(req.nextUrl.searchParams.get("limit") || "20");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+
+    const res = await commentClient.listReplies({ commentId, limit, cursor }, { headers });
+    return NextResponse.json({
+      comments: (res.replies || []).map(mapCommentToView),
+      nextCursor: res.nextCursor || "",
+      hasMore: !!res.hasMore,
+    });
+  } catch (error: unknown) {
+    return handleApiError(error, "ListReplies");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/[id]/comments/[commentId]/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/[id]/comments/[commentId]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { commentClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> }
+) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const { commentId } = await params;
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await commentClient.deleteComment({ commentId }, { headers });
+    return NextResponse.json({ commentsCount: res.commentsCount });
+  } catch (error: unknown) {
+    return handleApiError(error, "DeleteComment");
+  }
+}

--- a/services/frontend/workspace/src/modules/post/components/CommentList.tsx
+++ b/services/frontend/workspace/src/modules/post/components/CommentList.tsx
@@ -1,16 +1,23 @@
 "use client";
 
+import { useState } from "react";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { formatTimeAgo } from "@/lib/utils/date";
 import { useComments } from "@/modules/post/hooks/useComments";
+import { useDeleteComment } from "@/modules/post/hooks/useDeleteComment";
+import { ReplyList } from "./ReplyList";
+import { useAuthStore, selectUserId } from "@/stores/authStore";
 
 interface CommentListProps {
   postId: string;
 }
 
 export function CommentList({ postId }: CommentListProps) {
+  const viewerId = useAuthStore(selectUserId);
   const { comments, hasMore, loading, error, loadMore } = useComments(postId);
+  const { deleteComment, submitting: deleting } = useDeleteComment(postId);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
   if (loading && comments.length === 0) {
     return <p className="px-4 py-4 text-text-secondary">読み込み中…</p>;
@@ -22,27 +29,60 @@ export function CommentList({ postId }: CommentListProps) {
     return <p className="px-4 py-4 text-text-secondary">まだコメントはありません</p>;
   }
 
+  const onDelete = async (commentId: string) => {
+    if (!confirm("このコメントを削除しますか?")) return;
+    await deleteComment(commentId).catch(() => {});
+  };
+
   return (
     <div>
-      {comments.map((c) => (
-        <article key={c.id} className="flex gap-3 border-b border-divider px-4 py-3">
-          <Avatar
-            src={c.author?.imageUrl || undefined}
-            fallback={(c.author?.name || "?").slice(0, 1)}
-            size="sm"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1 text-sm">
-              <span className="font-bold text-text-primary">{c.author?.name || "—"}</span>
-              <span className="text-text-muted">· {c.createdAt ? formatTimeAgo(c.createdAt) : ""}</span>
-            </div>
-            <p className="mt-1 whitespace-pre-wrap text-text-primary">{c.content}</p>
-            {c.repliesCount > 0 && (
-              <p className="mt-2 text-xs text-text-secondary">{c.repliesCount} 件の返信</p>
-            )}
+      {comments.map((c) => {
+        const isOwn = !!viewerId && c.userId === viewerId;
+        const isExpanded = !!expanded[c.id];
+        return (
+          <div key={c.id}>
+            <article className="flex gap-3 border-b border-divider px-4 py-3">
+              <Avatar
+                src={c.author?.imageUrl || undefined}
+                fallback={(c.author?.name || "?").slice(0, 1)}
+                size="sm"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1 text-sm">
+                  <span className="font-bold text-text-primary">{c.author?.name || "—"}</span>
+                  <span className="text-text-muted">· {c.createdAt ? formatTimeAgo(c.createdAt) : ""}</span>
+                </div>
+                <p className="mt-1 whitespace-pre-wrap text-text-primary">{c.content}</p>
+                <div className="mt-2 flex items-center gap-4 text-xs">
+                  {c.repliesCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setExpanded((prev) => ({ ...prev, [c.id]: !prev[c.id] }))
+                      }
+                      className="text-text-secondary hover:text-text-primary"
+                      aria-expanded={isExpanded}
+                    >
+                      {isExpanded ? "返信を隠す" : `${c.repliesCount} 件の返信を見る`}
+                    </button>
+                  )}
+                  {isOwn && (
+                    <button
+                      type="button"
+                      onClick={() => onDelete(c.id)}
+                      disabled={deleting}
+                      className="text-text-muted hover:text-error disabled:opacity-50"
+                    >
+                      削除
+                    </button>
+                  )}
+                </div>
+              </div>
+            </article>
+            {isExpanded && <ReplyList postId={postId} commentId={c.id} />}
           </div>
-        </article>
-      ))}
+        );
+      })}
       {hasMore && (
         <div className="flex justify-center px-4 py-4">
           <Button variant="secondary" size="md" onClick={() => loadMore()} disabled={loading}>

--- a/services/frontend/workspace/src/modules/post/components/ReplyList.tsx
+++ b/services/frontend/workspace/src/modules/post/components/ReplyList.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Avatar } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { formatTimeAgo } from "@/lib/utils/date";
+import { useReplies } from "@/modules/post/hooks/useReplies";
+import { useDeleteComment } from "@/modules/post/hooks/useDeleteComment";
+import { useAuthStore, selectUserId } from "@/stores/authStore";
+
+interface ReplyListProps {
+  postId: string;
+  commentId: string;
+}
+
+export function ReplyList({ postId, commentId }: ReplyListProps) {
+  const viewerId = useAuthStore(selectUserId);
+  const { replies, hasMore, loading, error, loadMore } = useReplies(postId, commentId, true);
+  const { deleteComment, submitting: deleting } = useDeleteComment(postId);
+
+  if (loading && replies.length === 0) {
+    return <p className="py-2 pl-12 pr-4 text-sm text-text-secondary">読み込み中…</p>;
+  }
+  if (error) {
+    return <p className="py-2 pl-12 pr-4 text-sm text-text-secondary">読み込みに失敗しました</p>;
+  }
+  if (!loading && replies.length === 0) {
+    return <p className="py-2 pl-12 pr-4 text-sm text-text-secondary">返信はまだありません</p>;
+  }
+
+  const onDelete = async (id: string) => {
+    if (!confirm("この返信を削除しますか?")) return;
+    await deleteComment(id).catch(() => {});
+  };
+
+  return (
+    <div className="bg-bg-secondary/30">
+      {replies.map((r) => {
+        const isOwn = !!viewerId && r.userId === viewerId;
+        return (
+          <article key={r.id} className="flex gap-3 border-b border-divider py-3 pl-12 pr-4">
+            <Avatar
+              src={r.author?.imageUrl || undefined}
+              fallback={(r.author?.name || "?").slice(0, 1)}
+              size="sm"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1 text-sm">
+                <span className="font-bold text-text-primary">{r.author?.name || "—"}</span>
+                <span className="text-text-muted">· {r.createdAt ? formatTimeAgo(r.createdAt) : ""}</span>
+              </div>
+              <p className="mt-1 whitespace-pre-wrap text-text-primary">{r.content}</p>
+              {isOwn && (
+                <button
+                  type="button"
+                  onClick={() => onDelete(r.id)}
+                  disabled={deleting}
+                  className="mt-2 text-xs text-text-muted hover:text-error disabled:opacity-50"
+                >
+                  削除
+                </button>
+              )}
+            </div>
+          </article>
+        );
+      })}
+      {hasMore && (
+        <div className="flex justify-center py-2 pl-12 pr-4">
+          <Button variant="secondary" size="sm" onClick={() => loadMore()} disabled={loading}>
+            返信をもっと見る
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useDeleteComment.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useDeleteComment.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useSWRConfig } from "swr";
+import { authFetch } from "@/lib/auth";
+
+export function useDeleteComment(postId: string | null | undefined) {
+  const { mutate } = useSWRConfig();
+  const [submitting, setSubmitting] = useState(false);
+
+  const deleteComment = useCallback(
+    async (commentId: string) => {
+      if (!postId || !commentId) return;
+
+      setSubmitting(true);
+      try {
+        await authFetch(
+          `/api/posts/${encodeURIComponent(postId)}/comments/${encodeURIComponent(commentId)}`,
+          { method: "DELETE" }
+        );
+        mutate(
+          (key) =>
+            typeof key === "string" &&
+            key.startsWith(`/api/posts/${encodeURIComponent(postId)}/comments`)
+        );
+        mutate(`/api/posts/${encodeURIComponent(postId)}`);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [postId, mutate]
+  );
+
+  return { deleteComment, submitting };
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useReplies.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useReplies.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import useSWRInfinite from "swr/infinite";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PaginatedCommentsResponse } from "@/modules/post/lib/comment-view";
+
+export function useReplies(
+  postId: string | null | undefined,
+  commentId: string | null | undefined,
+  enabled: boolean
+) {
+  const token = getAuthToken();
+
+  const getKey = (pageIndex: number, prev: PaginatedCommentsResponse | null): string | null => {
+    if (!enabled || !token || !postId || !commentId) return null;
+    if (prev && !prev.hasMore) return null;
+    const base = `/api/posts/${encodeURIComponent(postId)}/comments/${encodeURIComponent(commentId)}/replies`;
+    return pageIndex === 0 ? base : `${base}?cursor=${encodeURIComponent(prev?.nextCursor || "")}`;
+  };
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<PaginatedCommentsResponse>(getKey, fetcher, { revalidateOnFocus: false });
+
+  const pages = data || [];
+  const replies = pages.flatMap((p) => p.comments || []);
+  const hasMore = pages.length > 0 ? !!pages[pages.length - 1].hasMore : false;
+
+  return {
+    replies,
+    hasMore,
+    loading: isLoading || isValidating,
+    error,
+    loadMore: () => setSize(size + 1),
+    refresh: () => mutate(),
+  };
+}


### PR DESCRIPTION
## Summary

Posts polish C: \`/posts/[id]\` のコメント表示に **delete (own only) と replies expansion** を追加。Polish A (#704) + B (#705) で list + add を実装済、本 PR で **削除** と **返信展開** を追加して comments read/write の主要 UX が一通り揃う。

### 内訳

- **2 new BFFs**:
  - \`DELETE /api/posts/[id]/comments/[commentId]\` — \`commentClient.deleteComment\`、レスポンスに \`commentsCount\` を返す
  - \`GET /api/posts/[id]/comments/[commentId]/replies\` — \`commentClient.listReplies\`、cursor pagination、shape は ListComments と同 \`{comments, nextCursor, hasMore}\`
- **2 new hooks**:
  - \`useDeleteComment(postId)\` — confirm 込み呼出、submit 後に SWR comment-list + post detail invalidate
  - \`useReplies(postId, commentId, enabled)\` — useSWRInfinite + cursor、\`enabled\` false 時は fetch しない (展開時のみ)
- **1 new component**: \`ReplyList.tsx\` (展開時に inline 表示、自分の reply に削除 button)
- **CommentList 拡張**:
  - viewer == comment author の時のみ「削除」link 表示
  - \`repliesCount > 0\` のコメントに「N 件の返信を見る」/「返信を隠す」toggle、展開時に \`<ReplyList />\` を nest render

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑、新 2 BFF route が build 出力に登場
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)

## Notes

- **reply composer (return 投稿)** は今回 scope 外。展開後の reply 一覧は read-only。次の Polish D で reply 用 CommentComposer 拡張 (parentId 渡し) を検討余地。
- 削除 button は author 一致 + 確認 \`confirm()\` 経由、cross-account 削除は monolith 側 \`delete_comment_uc\` が \`CommentNotFoundOrUnauthorizedError\` で防御済。
- 削除後の SWR invalidate でリスト + commentsCount が自動更新。

## Decomposition (comments 系)

- Polish A #704 (list)
- Polish B #705 (add)
- **Polish C (本 PR)** (delete + replies expansion)
- (Polish D 余地): reply composer (parentId 指定可能な CommentComposer)