### PR TITLE
feat(messaging): StartChatButton on /u/[username] (GetOrCreateThread + navigate)

### DIFF
--- a/services/frontend/workspace/src/app/u/[username]/page.tsx
+++ b/services/frontend/workspace/src/app/u/[username]/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { usePublicProfile } from "@/modules/profile/hooks";
 import { ProfileHeader } from "@/modules/profile/components/ProfileHeader";
 import { FollowButton, BlockButton, useSocialCounts } from "@/modules/social";
+import { StartChatButton } from "@/modules/messaging";
 
 export default function PublicProfilePage() {
   const params = useParams<{ username: string }>();
@@ -28,6 +29,7 @@ export default function PublicProfilePage() {
       <ProfileHeader profile={profile} role={role} />
       <div className="flex items-center gap-2 px-4 pt-3">
         <FollowButton targetAccountId={profile.accountId} />
+        <StartChatButton targetAccountId={profile.accountId} />
         <BlockButton targetAccountId={profile.accountId} />
       </div>
       <div className="flex gap-4 px-4 pt-3 text-sm text-text-secondary">

--- a/services/frontend/workspace/src/modules/messaging/components/StartChatButton.tsx
+++ b/services/frontend/workspace/src/modules/messaging/components/StartChatButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { authFetch } from "@/lib/auth";
+import { useAuthStore, selectUserId } from "@/stores/authStore";
+import type { ThreadView } from "@/modules/messaging/types";
+
+interface StartChatButtonProps {
+  targetAccountId: string;
+  className?: string;
+}
+
+interface GetOrCreateThreadResponse {
+  thread: ThreadView | null;
+}
+
+export function StartChatButton({ targetAccountId, className }: StartChatButtonProps) {
+  const router = useRouter();
+  const viewerId = useAuthStore(selectUserId);
+  const [loading, setLoading] = useState(false);
+
+  const onClick = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const res = await authFetch<GetOrCreateThreadResponse>("/api/messaging/threads", {
+        method: "POST",
+        body: { recipientAccountId: targetAccountId },
+      });
+      if (res.thread?.id) {
+        router.push(`/messages/${encodeURIComponent(res.thread.id)}`);
+      } else {
+        alert("メッセージスレッドの作成に失敗しました");
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "メッセージを送れません";
+      alert(message || "相互フォロー関係でない可能性があります");
+    } finally {
+      setLoading(false);
+    }
+  }, [targetAccountId, loading, router]);
+
+  if (!targetAccountId || !viewerId || viewerId === targetAccountId) return null;
+
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={onClick}
+      disabled={loading}
+      className={className}
+    >
+      {loading ? "起動中…" : "メッセージを送る"}
+    </Button>
+  );
+}

--- a/services/frontend/workspace/src/modules/messaging/index.ts
+++ b/services/frontend/workspace/src/modules/messaging/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./hooks";
 export { MessagingStreamProvider } from "./providers/MessagingStreamProvider";
+export { StartChatButton } from "./components/StartChatButton";


### PR DESCRIPTION
## Summary

messaging slice spec で defer されていた **DM 起点 UI** を実装。\`/u/[username]\` プロフィールページに「メッセージを送る」button を追加し、tap で \`GetOrCreateThread\` RPC を呼んで \`/messages/[id]\` へ navigate。これで messaging slice (#710-#714) が UI 経由で完全到達可能に。

### 内訳

- **新規**: \`src/modules/messaging/components/StartChatButton.tsx\`
  - viewer == owner 時は自動非描画
  - click → \`POST /api/messaging/threads { recipientAccountId }\` → \`router.push(/messages/[id])\`
  - error は \`alert\` で表示 (相互フォロー外 / block 等)
- **\`src/modules/messaging/index.ts\`**: \`StartChatButton\` re-export 追加
- **\`/u/[username]\` 拡張**: FollowButton + StartChatButton + BlockButton の順に並置

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)

## Notes

- backend validation (相互 followers / block) は M1 (#711) の \`SendMessage\` / \`GetOrCreateThread\` use_case で実装済、本 PR は frontend 起点動線のみ追加
- error UX は \`alert()\` で MVP 対応、別 PR で trabaja modal / toast 化余地

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now start direct messages from public profiles. A message button has been added to the profile header for quick conversation initiation. The feature is unavailable when viewing your own profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->