### PR TITLE
feat(ui): visual polish tier 1 (bg-bg-secondary token + Drawer animation + search clear button)

### DIFF
--- a/services/frontend/workspace/src/app/globals.css
+++ b/services/frontend/workspace/src/app/globals.css
@@ -32,6 +32,7 @@
 
   /* Semantic aliases */
   --color-bg: var(--color-neutral-950);
+  --color-bg-secondary: var(--color-neutral-800);
   --color-surface: var(--color-neutral-900);
   --color-divider: var(--color-neutral-800);
   --color-border: var(--color-neutral-700);
@@ -95,6 +96,7 @@ html {
 
   /* Semantic */
   --color-bg: var(--color-bg);
+  --color-bg-secondary: var(--color-bg-secondary);
   --color-surface: var(--color-surface);
   --color-divider: var(--color-divider);
   --color-border: var(--color-border);

--- a/services/frontend/workspace/src/app/search/page.tsx
+++ b/services/frontend/workspace/src/app/search/page.tsx
@@ -26,13 +26,26 @@ export default function SearchPage() {
   return (
     <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
       <div className="sticky top-0 z-10 bg-bg/95 px-4 py-3 backdrop-blur">
-        <Input
-          type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="ユーザーや投稿を検索"
-          aria-label="検索"
-        />
+        <div className="relative">
+          <Input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="ユーザーや投稿を検索"
+            aria-label="検索"
+            className="pr-9"
+          />
+          {query.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-text-secondary hover:text-text-primary"
+              aria-label="検索をクリア"
+            >
+              ✕
+            </button>
+          )}
+        </div>
       </div>
       <Tabs items={TABS} value={tab} onValueChange={setTab} />
 

--- a/services/frontend/workspace/src/components/shell/Drawer.tsx
+++ b/services/frontend/workspace/src/components/shell/Drawer.tsx
@@ -48,19 +48,22 @@ export function Drawer({ open, onClose }: DrawerProps) {
     router.push("/");
   };
 
-  if (!open) return null;
-
   return (
     <>
       <div
-        className="fixed inset-0 z-40 bg-black/60"
+        className={`fixed inset-0 z-40 bg-black/60 transition-opacity duration-200 ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
         onClick={onClose}
         aria-hidden="true"
       />
       <aside
-        className="fixed left-0 top-0 z-50 flex h-full w-80 max-w-[80vw] flex-col bg-bg shadow-2xl"
+        className={`fixed left-0 top-0 z-50 flex h-full w-80 max-w-[80vw] flex-col bg-bg shadow-2xl transition-transform duration-300 ease-out ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
         role="dialog"
         aria-label="メニュー"
+        aria-hidden={!open}
       >
         <div className="border-b border-border px-4 py-4">
           <Avatar


### PR DESCRIPTION
## Summary

rx-sns visual gap audit Tier 1 (即効 polish 集約)。3 つの小さな polish を 1 PR にまとめ:

1. **\`bg-bg-secondary\` token 追加**: 既存 page (notifications / oshi / bookmarks / chat 等) で頻出するが \`globals.css\` に未定義で Tailwind が unknown class として無視していた。\`--color-bg-secondary: var(--color-neutral-800)\` を \`:root\` + \`@theme inline\` に追加、全 \`bg-bg-secondary*\` クラスが正しく適用されるように。
2. **Drawer slide-in animation**: 旧 \`if (!open) return null\` の即時表示/非表示を、常駐 + transition class toggle に変更。overlay opacity 200ms + slide-in 300ms ease-out で滑らかに開閉。a11y は \`aria-hidden={!open}\` 追加。
3. **/search 入力 clear button (✕)**: query 入力時に右側に X icon を表示、click で \`setQuery("")\`。input に \`pr-9\` を追加して text 重なり回避。

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)

## Spec / Audit

audit report は session 内で提示済、Tier 2-3 は別 PR で進行予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search input now displays a clear button when text is entered for easier query reset.

* **Style**
  * Added secondary background color styling variable for consistent theme application.

* **Improvements**
  * Enhanced drawer component accessibility with better visibility controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->