### PR TITLE
feat(ui): visual polish tier 2 (role badge + 登録日 + drawer profile link to /u/[me])

### DIFF
--- a/services/frontend/workspace/src/components/shell/Drawer.tsx
+++ b/services/frontend/workspace/src/components/shell/Drawer.tsx
@@ -11,7 +11,7 @@ import { useTotalUnread } from "@/modules/messaging";
 import { useAuthStore } from "@/stores/authStore";
 
 const NAV_ITEMS = [
-  { path: "/profile", label: "プロフィール", icon: "👤" },
+  { path: "__profile__", label: "プロフィール", icon: "👤" },
   { path: "/search", label: "検索", icon: "🔍" },
   { path: "/notifications", label: "通知", icon: "🔔", badgeKey: "unread" as const },
   { path: "/footprints", label: "足跡", icon: "👣" },
@@ -87,10 +87,14 @@ export function Drawer({ open, onClose }: DrawerProps) {
               item.badgeKey === "messaging_unread" ? msgUnread :
               0;
             const showBadge = badgeCount > 0;
+            const href =
+              item.path === "__profile__"
+                ? (profile?.username ? `/u/${encodeURIComponent(profile.username)}` : "/profile")
+                : item.path;
             return (
               <Link
                 key={item.path}
-                href={item.path}
+                href={href}
                 onClick={onClose}
                 className="flex items-center gap-3 px-4 py-3 text-text-primary hover:bg-bg-secondary"
               >

--- a/services/frontend/workspace/src/modules/profile/components/ProfileHeader.tsx
+++ b/services/frontend/workspace/src/modules/profile/components/ProfileHeader.tsx
@@ -18,9 +18,17 @@ interface ProfileHeaderProps {
   onEdit?: () => void;
 }
 
+function formatRegisteredAt(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}年${d.getMonth() + 1}月に登録`;
+}
+
 export function ProfileHeader({ profile, role, onEdit }: ProfileHeaderProps) {
   const isCast = role === "cast";
   const sns = SNS_LABELS.filter(({ key }) => profile.snsLinks[key]);
+  const registeredLabel = formatRegisteredAt(profile.registeredAt);
 
   return (
     <div className="flex flex-col">
@@ -52,12 +60,19 @@ export function ProfileHeader({ profile, role, onEdit }: ProfileHeaderProps) {
       <div className="flex flex-col gap-1 px-4 pt-2">
         <div className="flex items-center gap-2">
           <h1 className="text-xl font-bold text-text-primary">{profile.displayName}</h1>
-          {isCast && (
-            <span className="rounded-full bg-accent/15 px-2 py-0.5 text-xs text-accent">セラピスト</span>
-          )}
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs ${
+              isCast ? "bg-accent/15 text-accent" : "bg-text-secondary/10 text-text-secondary"
+            }`}
+          >
+            {isCast ? "セラピスト" : "ユーザー"}
+          </span>
         </div>
         <p className="text-sm text-text-secondary">@{profile.username || "—"}</p>
-        {profile.prefecture && <p className="text-sm text-text-secondary">📍 {profile.prefecture}</p>}
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-text-secondary">
+          {profile.prefecture && <span>📍 {profile.prefecture}</span>}
+          {registeredLabel && <span>🗓 {registeredLabel}</span>}
+        </div>
         {profile.bio && <p className="whitespace-pre-wrap pt-1 text-sm text-text-primary">{profile.bio}</p>}
         {profile.website && (
           <a


### PR DESCRIPTION
## Summary

rx-sns visual gap audit Tier 2。\`/u/[username]\` プロフィール表示の情報量と drawer の動線を rx-sns 準拠に近づける 3 件の polish。

### 内訳

- **\`ProfileHeader\` に「ユーザー」badge**: 旧仕様は isCast 時のみ「セラピスト」pill を表示。非 cast 時は表示なしだったが、rx-sns では全員に role 表示あり (\`ユーザー\`)。\`isCast ? accent tone : text-secondary tone\` で switch。
- **\`ProfileHeader\` に登録日表示**: \`profile.registeredAt\` を ISO8601 → "YYYY年M月に登録" にフォーマットして prefecture と並列に 🗓 icon 付きで表示。
- **Drawer の「プロフィール」リンク**: 旧 \`/profile\` (= my profile editor) ではなく \`/u/[viewer username]\` (= 公開プロフィール) に向ける。username 未取得時は \`/profile\` fallback。NAV_ITEMS の path に sentinel \`__profile__\` を入れ、render 時に viewer 情報で resolve。

### Verification

- \`tsc --noEmit\` 緑
- \`pnpm build\` 緑
- \`pnpm lint\` baseline 維持 (5 errors / 7 warnings、本 PR 増減なし)

## Spec / Audit

audit report の Tier 2 polish を回収。Tier 3 (content tabs on /u/[username]) は別 PR / 別 spec 起こしから。