### PR TITLE
feat(frontend): profile tabs data layer (media filter, comments-by-author, liked-by)

### DIFF
--- a/services/frontend/workspace/src/app/api/posts/comments-by-author/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/comments-by-author/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { commentClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { mapCommentToView } from "@/modules/post/lib/comment-mappers";
+import { mapPostToView } from "@/modules/post/lib/post-mappers";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const authorId = req.nextUrl.searchParams.get("author_id") || "";
+    const limit = Number(req.nextUrl.searchParams.get("limit") || "20");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+
+    const res = await commentClient.listCommentsByAuthor(
+      { authorId, limit, cursor },
+      { headers }
+    );
+
+    const postsByIdMap: Record<string, ReturnType<typeof mapPostToView>> = {};
+    for (const [pid, post] of Object.entries(res.postsById || {})) {
+      postsByIdMap[pid] = mapPostToView(post);
+    }
+
+    return NextResponse.json({
+      comments: (res.comments || []).map(mapCommentToView),
+      postsById: postsByIdMap,
+      nextCursor: res.nextCursor || "",
+      hasMore: !!res.hasMore,
+    });
+  } catch (error: unknown) {
+    return handleApiError(error, "ListCommentsByAuthor");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/liked-by/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/liked-by/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { likeClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { mapPostToView } from "@/modules/post/lib/post-mappers";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const accountId = req.nextUrl.searchParams.get("account_id") || "";
+    const limit = Number(req.nextUrl.searchParams.get("limit") || "20");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+
+    const res = await likeClient.listLikedPostsByAccount(
+      { accountId, limit, cursor },
+      { headers }
+    );
+
+    return NextResponse.json({
+      posts: (res.posts || []).map(mapPostToView),
+      nextCursor: res.nextCursor || "",
+      hasMore: !!res.hasMore,
+    });
+  } catch (error: unknown) {
+    return handleApiError(error, "ListLikedPostsByAccount");
+  }
+}

--- a/services/frontend/workspace/src/app/api/posts/route.ts
+++ b/services/frontend/workspace/src/app/api/posts/route.ts
@@ -18,9 +18,10 @@ export async function GET(req: NextRequest) {
     const { limit, cursor } = extractPaginationParams(req.nextUrl.searchParams);
     const authorId = req.nextUrl.searchParams.get("author_id") || "";
     const filter = req.nextUrl.searchParams.get("filter") || "";
+    const mediaOnly = req.nextUrl.searchParams.get("media_only") === "1";
 
     const res = await postClient.listPosts(
-      { limit, cursor, authorId, filter },
+      { limit, cursor, authorId, filter, mediaOnly },
       { headers }
     );
     return NextResponse.json(mapPostsListResponse(res));

--- a/services/frontend/workspace/src/modules/post/hooks/index.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/index.ts
@@ -1,3 +1,6 @@
 export { usePosts } from "./usePosts";
 export { usePost } from "./usePost";
 export { usePostLike } from "./usePostLike";
+export { useAuthorPosts } from "./useAuthorPosts";
+export { useAuthorComments } from "./useAuthorComments";
+export { useAuthorLikedPosts } from "./useAuthorLikedPosts";

--- a/services/frontend/workspace/src/modules/post/hooks/useAuthorComments.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useAuthorComments.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import useSWRInfinite from "swr/infinite";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PaginatedAuthorCommentsResponse } from "@/modules/post/lib/author-tab-view";
+import type { PostView } from "@/modules/post/lib/post-view";
+
+export function useAuthorComments(accountId: string | null | undefined) {
+  const token = getAuthToken();
+
+  const getKey = (pageIndex: number, prev: PaginatedAuthorCommentsResponse | null): string | null => {
+    if (!token || !accountId) return null;
+    if (prev && !prev.hasMore) return null;
+    const cursorQs = pageIndex === 0 ? "" : `&cursor=${encodeURIComponent(prev?.nextCursor || "")}`;
+    return `/api/posts/comments-by-author?author_id=${encodeURIComponent(accountId)}${cursorQs}`;
+  };
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<PaginatedAuthorCommentsResponse>(getKey, fetcher, { revalidateOnFocus: false });
+
+  const pages = data || [];
+  const comments = pages.flatMap((p) => p.comments || []);
+  // Merge postsById maps across all pages
+  const postsById: Record<string, PostView> = {};
+  for (const p of pages) {
+    Object.assign(postsById, p.postsById || {});
+  }
+  const hasMore = pages.length > 0 ? !!pages[pages.length - 1].hasMore : false;
+
+  return {
+    comments,
+    postsById,
+    hasMore,
+    loading: isLoading || isValidating,
+    error,
+    loadMore: () => setSize(size + 1),
+    refresh: () => mutate(),
+  };
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useAuthorLikedPosts.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useAuthorLikedPosts.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import useSWRInfinite from "swr/infinite";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PaginatedAuthorPostsResponse } from "@/modules/post/lib/author-tab-view";
+
+export function useAuthorLikedPosts(accountId: string | null | undefined) {
+  const token = getAuthToken();
+
+  const getKey = (pageIndex: number, prev: PaginatedAuthorPostsResponse | null): string | null => {
+    if (!token || !accountId) return null;
+    if (prev && !prev.hasMore) return null;
+    const cursorQs = pageIndex === 0 ? "" : `&cursor=${encodeURIComponent(prev?.nextCursor || "")}`;
+    return `/api/posts/liked-by?account_id=${encodeURIComponent(accountId)}${cursorQs}`;
+  };
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<PaginatedAuthorPostsResponse>(getKey, fetcher, { revalidateOnFocus: false });
+
+  const pages = data || [];
+  const posts = pages.flatMap((p) => p.posts || []);
+  const hasMore = pages.length > 0 ? !!pages[pages.length - 1].hasMore : false;
+
+  return {
+    posts,
+    hasMore,
+    loading: isLoading || isValidating,
+    error,
+    loadMore: () => setSize(size + 1),
+    refresh: () => mutate(),
+  };
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useAuthorPosts.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useAuthorPosts.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import useSWRInfinite from "swr/infinite";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PaginatedAuthorPostsResponse } from "@/modules/post/lib/author-tab-view";
+
+export function useAuthorPosts(accountId: string | null | undefined, mediaOnly: boolean) {
+  const token = getAuthToken();
+
+  const getKey = (pageIndex: number, prev: PaginatedAuthorPostsResponse | null): string | null => {
+    if (!token || !accountId) return null;
+    if (prev && !prev.hasMore) return null;
+    const params = new URLSearchParams();
+    params.set("author_id", accountId);
+    if (mediaOnly) params.set("media_only", "1");
+    if (pageIndex > 0 && prev?.nextCursor) params.set("cursor", prev.nextCursor);
+    return `/api/posts?${params.toString()}`;
+  };
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<PaginatedAuthorPostsResponse>(getKey, fetcher, { revalidateOnFocus: false });
+
+  const pages = data || [];
+  const posts = pages.flatMap((p) => p.posts || []);
+  const hasMore = pages.length > 0 ? !!pages[pages.length - 1].hasMore : false;
+
+  return {
+    posts,
+    hasMore,
+    loading: isLoading || isValidating,
+    error,
+    loadMore: () => setSize(size + 1),
+    refresh: () => mutate(),
+  };
+}

--- a/services/frontend/workspace/src/modules/post/lib/author-tab-view.ts
+++ b/services/frontend/workspace/src/modules/post/lib/author-tab-view.ts
@@ -1,0 +1,17 @@
+import type { CommentView } from "./comment-view";
+import type { PostView } from "./post-view";
+
+export type ProfileTabKind = "posts" | "replies" | "media" | "likes";
+
+export interface PaginatedAuthorPostsResponse {
+  posts: PostView[];
+  nextCursor: string;
+  hasMore: boolean;
+}
+
+export interface PaginatedAuthorCommentsResponse {
+  comments: CommentView[];
+  postsById: Record<string, PostView>;
+  nextCursor: string;
+  hasMore: boolean;
+}


### PR DESCRIPTION
## Summary

Tier 3 profile content tabs の P2 (frontend data layer)。P1 で監督した monolith RPC 拡張 (#719) を活用し、4 タブ分のデータ取得経路を整備する。

### Added
- `src/modules/post/lib/author-tab-view.ts` — `ProfileTabKind` / `PaginatedAuthorPostsResponse` / `PaginatedAuthorCommentsResponse` 型
- `src/modules/post/hooks/useAuthorPosts.ts` — `accountId` + `mediaOnly` 引数。media フィルタ対応
- `src/modules/post/hooks/useAuthorComments.ts` — `postsById` map をページ間でマージし、返信タブの親ポスト hydration を提供
- `src/modules/post/hooks/useAuthorLikedPosts.ts` — 任意アカウントのいいね一覧
- `src/app/api/posts/comments-by-author/route.ts` BFF
- `src/app/api/posts/liked-by/route.ts` BFF

### Changed
- `src/app/api/posts/route.ts` — `media_only=1` query string を `mediaOnly` boolean として listPosts に伝搬

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline 維持)
- tsc --noEmit: success

## Stack
- Spec: docs/superpowers/specs/2026-06-17-profile-content-tabs-design.md (#718)
- P1: #719 (monolith proto + use_cases + handlers)
- **P2: this PR**
- P3: pending (profile page tabs UI + reply row component)