### PR TITLE
feat(frontend): profile content tabs UI (posts/replies/media/likes)

### DIFF
--- a/services/frontend/workspace/src/app/u/[username]/page.tsx
+++ b/services/frontend/workspace/src/app/u/[username]/page.tsx
@@ -5,6 +5,7 @@ import { usePublicProfile } from "@/modules/profile/hooks";
 import { ProfileHeader } from "@/modules/profile/components/ProfileHeader";
 import { FollowButton, BlockButton, useSocialCounts } from "@/modules/social";
 import { StartChatButton } from "@/modules/messaging";
+import { ProfileContentTabs } from "@/modules/post/components/ProfileContentTabs";
 
 export default function PublicProfilePage() {
   const params = useParams<{ username: string }>();
@@ -40,6 +41,7 @@ export default function PublicProfilePage() {
           <strong className="text-text-primary">{counts.followersCount}</strong> フォロワー
         </span>
       </div>
+      <ProfileContentTabs accountId={profile.accountId} />
     </main>
   );
 }

--- a/services/frontend/workspace/src/modules/post/components/ProfileContentTabs.tsx
+++ b/services/frontend/workspace/src/modules/post/components/ProfileContentTabs.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { Tabs } from "@/components/ui/tab";
+import { Button } from "@/components/ui/button";
+import { PostCardBinding } from "./PostCardBinding";
+import { ReplyWithParentRow } from "./ReplyWithParentRow";
+import { useAuthorPosts } from "@/modules/post/hooks/useAuthorPosts";
+import { useAuthorComments } from "@/modules/post/hooks/useAuthorComments";
+import { useAuthorLikedPosts } from "@/modules/post/hooks/useAuthorLikedPosts";
+import type { ProfileTabKind } from "@/modules/post/lib/author-tab-view";
+
+const TAB_ITEMS = [
+  { id: "posts", label: "投稿" },
+  { id: "replies", label: "返信" },
+  { id: "media", label: "メディア" },
+  { id: "likes", label: "いいね" },
+] as const;
+
+export interface ProfileContentTabsProps {
+  accountId: string;
+}
+
+export function ProfileContentTabs({ accountId }: ProfileContentTabsProps) {
+  const [tab, setTab] = useState<ProfileTabKind>("posts");
+
+  return (
+    <section className="mt-4">
+      <Tabs
+        items={TAB_ITEMS as unknown as { id: string; label: string }[]}
+        value={tab}
+        onValueChange={(id) => setTab(id as ProfileTabKind)}
+      />
+      <div>
+        {tab === "posts" && <AuthorPostsPane accountId={accountId} mediaOnly={false} />}
+        {tab === "replies" && <AuthorRepliesPane accountId={accountId} />}
+        {tab === "media" && <AuthorPostsPane accountId={accountId} mediaOnly={true} />}
+        {tab === "likes" && <AuthorLikesPane accountId={accountId} />}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return <p className="px-4 py-8 text-center text-text-secondary">{message}</p>;
+}
+
+function LoadMore({ hasMore, loading, onClick }: { hasMore: boolean; loading: boolean; onClick: () => void }) {
+  if (!hasMore) return null;
+  return (
+    <div className="flex justify-center py-4">
+      <Button variant="secondary" size="sm" onClick={onClick} disabled={loading}>
+        {loading ? "読み込み中…" : "もっと見る"}
+      </Button>
+    </div>
+  );
+}
+
+function AuthorPostsPane({ accountId, mediaOnly }: { accountId: string; mediaOnly: boolean }) {
+  const { posts, hasMore, loading, error, loadMore } = useAuthorPosts(accountId, mediaOnly);
+  if (loading && posts.length === 0) return <EmptyState message="読み込み中…" />;
+  if (error) return <EmptyState message="読み込みに失敗しました" />;
+  if (posts.length === 0)
+    return <EmptyState message={mediaOnly ? "メディア付きの投稿はありません" : "まだ投稿はありません"} />;
+  return (
+    <div>
+      {posts.map((p) => (
+        <PostCardBinding key={p.id} post={p} />
+      ))}
+      <LoadMore hasMore={hasMore} loading={loading} onClick={loadMore} />
+    </div>
+  );
+}
+
+function AuthorRepliesPane({ accountId }: { accountId: string }) {
+  const { comments, postsById, hasMore, loading, error, loadMore } = useAuthorComments(accountId);
+  if (loading && comments.length === 0) return <EmptyState message="読み込み中…" />;
+  if (error) return <EmptyState message="読み込みに失敗しました" />;
+  if (comments.length === 0) return <EmptyState message="まだ返信はありません" />;
+  return (
+    <div>
+      {comments.map((c) => (
+        <ReplyWithParentRow key={c.id} comment={c} parentPost={postsById[c.postId] || null} />
+      ))}
+      <LoadMore hasMore={hasMore} loading={loading} onClick={loadMore} />
+    </div>
+  );
+}
+
+function AuthorLikesPane({ accountId }: { accountId: string }) {
+  const { posts, hasMore, loading, error, loadMore } = useAuthorLikedPosts(accountId);
+  if (loading && posts.length === 0) return <EmptyState message="読み込み中…" />;
+  if (error) return <EmptyState message="読み込みに失敗しました" />;
+  if (posts.length === 0) return <EmptyState message="まだいいねした投稿はありません" />;
+  return (
+    <div>
+      {posts.map((p) => (
+        <PostCardBinding key={p.id} post={p} />
+      ))}
+      <LoadMore hasMore={hasMore} loading={loading} onClick={loadMore} />
+    </div>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/components/ReplyWithParentRow.tsx
+++ b/services/frontend/workspace/src/modules/post/components/ReplyWithParentRow.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { Avatar } from "@/components/ui/avatar";
+import { formatTimeAgo } from "@/lib/utils/date";
+import type { CommentView } from "@/modules/post/lib/comment-view";
+import type { PostView } from "@/modules/post/lib/post-view";
+
+export interface ReplyWithParentRowProps {
+  comment: CommentView;
+  parentPost: PostView | null;
+}
+
+export function ReplyWithParentRow({ comment, parentPost }: ReplyWithParentRowProps) {
+  const detailHref = `/posts/${encodeURIComponent(comment.postId)}`;
+  return (
+    <article className="border-b border-divider px-4 py-3">
+      {parentPost ? (
+        <Link
+          href={detailHref}
+          className="mb-2 block rounded-md border border-divider/60 bg-bg-surface/40 p-3 hover:bg-bg-surface/70"
+        >
+          <div className="flex items-center gap-2 text-xs text-text-secondary">
+            <Avatar
+              src={parentPost.author?.avatarUrl || undefined}
+              fallback={(parentPost.author?.displayName || "?").slice(0, 1)}
+              size="sm"
+            />
+            <span className="font-bold text-text-primary">
+              {parentPost.author?.displayName || "名無し"}
+            </span>
+            <span>· {parentPost.createdAt ? formatTimeAgo(parentPost.createdAt) : ""}</span>
+          </div>
+          <p className="mt-1 line-clamp-2 text-sm text-text-primary">{parentPost.content}</p>
+        </Link>
+      ) : (
+        <div className="mb-2 rounded-md border border-divider/60 bg-bg-surface/40 p-3 text-xs text-text-muted">
+          元の投稿は表示できません
+        </div>
+      )}
+      <div className="flex gap-3">
+        <Avatar
+          src={comment.author?.imageUrl || undefined}
+          fallback={(comment.author?.name || "?").slice(0, 1)}
+          size="sm"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1 text-sm">
+            <span className="font-bold text-text-primary">{comment.author?.name || "—"}</span>
+            <span className="text-text-muted">
+              · {comment.createdAt ? formatTimeAgo(comment.createdAt) : ""}
+            </span>
+          </div>
+          <p className="mt-1 whitespace-pre-wrap text-text-primary">{comment.content}</p>
+        </div>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary

Tier 3 profile content tabs の最終 PR (P3)。/u/[username] にタブ UI を実装し、投稿/返信/メディア/いいね を rx-sns 同等に切り替え可能にする。

### Added
- `src/modules/post/components/ProfileContentTabs.tsx` — タブ container + 各 pane (Posts / Replies / Media / Likes)。状態は `useState<ProfileTabKind>`、ペイン切り替えで対応 hook を呼ぶ
- `src/modules/post/components/ReplyWithParentRow.tsx` — 返信タブ専用 row。親ポスト preview (avatar + 名前 + 2 行 line-clamp) を Link でラップし、その下にコメント本文を配置

### Changed
- `src/app/u/[username]/page.tsx` — `<ProfileContentTabs accountId={profile.accountId} />` をプロフィールヘッダ下に mount

### Behavior
- 投稿: `useAuthorPosts(accountId, false)` → `<PostCardBinding>` 縦リスト
- 返信: `useAuthorComments(accountId)` → `<ReplyWithParentRow>` (`postsById` で親 hydration)
- メディア: `useAuthorPosts(accountId, true)` (P2 で追加した media_only filter)
- いいね: `useAuthorLikedPosts(accountId)`
- 各タブで empty / loading / error / 「もっと見る」 ボタンによる cursor pagination をサポート

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline 維持)
- tsc --noEmit: success

## Stack
- Spec: docs/superpowers/specs/2026-06-17-profile-content-tabs-design.md (#718)
- P1: #719 (monolith proto + use_cases + handlers)
- P2: #720 (frontend data layer: hooks + BFFs)
- **P3: this PR**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced profile content tabs allowing users to view author posts, replies, media-only posts, and liked posts with pagination support.
  * Added reply display with parent post context, showing author information, timestamps, and graceful fallback when parent post is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->