### PR TITLE
fix(post): qualify PostPresenter in ListPostsByIds (feed crashes)

### DIFF
--- a/services/monolith/workspace/slices/post/use_cases/posts/list_posts_by_ids.rb
+++ b/services/monolith/workspace/slices/post/use_cases/posts/list_posts_by_ids.rb
@@ -43,7 +43,7 @@ module Post
           media_files = load_media_files(posts)
 
           posts.each_with_object({}) do |post, hash|
-            proto = PostPresenter.to_post_proto(
+            proto = Post::Presenters::PostPresenter.to_post_proto(
               post,
               author: authors[post.author_id],
               likes_count: likes_counts[post.id] || 0,


### PR DESCRIPTION
## Summary

Home feed が **\"読み込みに失敗しました\"** で表示できないバグの修正。

### Root cause

\`slices/post/use_cases/posts/list_posts_by_ids.rb:46\` で \`PostPresenter\` を unqualified で参照していた。\`grpc/handler.rb\` には \`PostPresenter = Post::Presenters::PostPresenter\` というスコープ内エイリアスがあるため \`grpc/post_handler.rb\` からは引けるが、\`Post::UseCases::Posts\` 名前空間からは \`Post::UseCases::Posts::ListPostsByIds::PostPresenter\` を探そうとして \`NameError\` で落ちる。

monolith ログから抽出:

\`\`\`
{\"severity\":\"ERROR\",\"method\":\"list_feed\",\"service\":\"feed.v1.feed_service\",
 \"error\":\"uninitialized constant Post::UseCases::Posts::ListPostsByIds::PostPresenter\",
 \"error_class\":\"NameError\"}
\`\`\`

Feed slice の \`list_feed\` は \`Post::Slice[\"use_cases.posts.list_posts_by_ids\"]\` で hydrate するため、すべての home feed 取得が 500 で失敗していた。Tier 3 でこの use_case が新規追加され、handler でしか使われていなかった symptom が cross-slice 経由で露呈した形。

### Fix

Bare \`PostPresenter\` を \`Post::Presenters::PostPresenter\` でフル修飾。

## Verification (local)

\`\`\`
$ curl -s \"http://localhost:3000/api/feed?filter=all&limit=20\" -H \"Authorization: Bearer \$TOKEN\"
HTTP 200
posts=14 hasMore=True firstAuthor=りん content=[Rin/Public/Public] カフェでまったり☕…
\`\`\`

修正前は HTTP 500 / 修正後は 200 + post 14 件返却を確認。puppeteer で home 画面の visual も確認済 (post カードがフィードとして縦並びに描画される)。

## Discovery context

rx-sns visual gap audit rev2 (Tier 1-3 完走後の現状監査) で発見。同監査で他の優先 gap (mobile drawer, 推し row on home, /profile own ページのタブ移植, settings 通知設定/外観タブ, footprints 本実装) を別途検出済。