### PR TITLE
feat(frontend): mount profile content tabs on /profile own page

### DIFF
--- a/services/frontend/workspace/src/app/profile/page.tsx
+++ b/services/frontend/workspace/src/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { useProfile } from "@/modules/profile/hooks";
 import { useAuthStore, selectRole, selectIsHydrated } from "@/stores/authStore";
 import { ProfileHeader } from "@/modules/profile/components/ProfileHeader";
 import { EditProfileModal } from "@/modules/profile/components/EditProfileModal";
+import { ProfileContentTabs } from "@/modules/post/components/ProfileContentTabs";
 
 export default function ProfilePage() {
   const isHydrated = useAuthStore(selectIsHydrated);
@@ -26,6 +27,7 @@ export default function ProfilePage() {
   return (
     <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
       <ProfileHeader profile={profile} role={role} onEdit={() => setEditing(true)} />
+      <ProfileContentTabs accountId={profile.accountId} />
       <EditProfileModal
         open={editing}
         onOpenChange={setEditing}


### PR DESCRIPTION
## Summary

`/profile` (自分のプロフィール) のレンダリングを rx-sns 同等に揃える。Tier 3 (#721) で `/u/[username]` (他人のプロフィール) に追加した `<ProfileContentTabs>` (投稿/返信/メディア/いいね) を own page にも mount し、対称な IA にする。

rx-sns visual gap audit rev2 で抽出した P1 ギャップ。

### Change

`src/app/profile/page.tsx`:
- import `ProfileContentTabs`
- `<ProfileHeader>` と `<EditProfileModal>` の間に `<ProfileContentTabs accountId={profile.accountId} />` を mount

### Behavior

`/u/[username]` と同じ 4 タブ動作:
- 投稿: 自分の post 一覧
- 返信: 自分のコメント (親 post hydration 付き)
- メディア: media_only=1 で絞った自分の post
- いいね: 自分がいいねした post

3 タブとも既存 hook (`useAuthorPosts` / `useAuthorComments` / `useAuthorLikedPosts`) を使うので backend 追加なし。

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline)
- tsc --noEmit: success

## Related

- Tier 3 P3 (#721) で `<ProfileContentTabs>` を新規作成、`/u/[username]` にのみ mount していた
- 監査結果 rev2 で `/profile` と `/u/[username]` のレンダリング非対称を発見

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile pages now include a new tabbed content section, allowing users to browse and navigate different categories of profile information in an organized manner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->