### PR TITLE
feat(frontend): drop placeholder header text and rename feed tab to 全国

### DIFF
--- a/services/frontend/workspace/src/app/page.tsx
+++ b/services/frontend/workspace/src/app/page.tsx
@@ -9,7 +9,7 @@ import { useProfile } from "@/modules/profile/hooks/useProfile";
 import type { FeedFilterValue } from "@/modules/feed/types";
 
 const TAB_ITEMS: TabItem[] = [
-  { id: "all", label: "全員" },
+  { id: "all", label: "全国" },
   { id: "area", label: "エリア" },
   { id: "following", label: "フォロー中" },
 ];

--- a/services/frontend/workspace/src/components/shell/TopBar.tsx
+++ b/services/frontend/workspace/src/components/shell/TopBar.tsx
@@ -22,7 +22,7 @@ export function TopBar({ onAvatarClick }: TopBarProps) {
       >
         <Avatar src={avatarUrl} fallback={fallback} size="sm" />
       </button>
-      <div className="text-base font-bold text-text-primary tracking-tight">dystopia.city</div>
+      <div aria-hidden="true" />
       <div className="w-8" aria-hidden="true" />
     </header>
   );


### PR DESCRIPTION
## Summary

rx-sns visual gap audit rev2 で検出した cosmetic P1/P2 を 2 件まとめて。

### Changes

**1. TopBar: 中央の "dystopia.city" placeholder を除去**

- 元: avatar (左) + "dystopia.city" (中央テキスト) + spacer (右)
- 修正後: avatar (左) + empty (中央) + spacer (右)
- 理由: rx-sns top header はロゴ + bell。本リポジトリには rx 同等の brand mark asset が無いため、まず placeholder テキストを除去するに留める。logo/bell の追加は別 PR で

**2. Home feed tab "全員" → "全国"**

- rx-sns の用語に合わせる (`/app/page.tsx`)

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline)
- tsc --noEmit: success

## Related
- 監査結果 rev2 (前ターン) の P1 cosmetic 項目
- 後続: 推し row on home (P1)、Footprints 本実装 (P1)、Settings 通知設定+外観 (P2)、Search role chips (P2)