### PR TITLE
feat(frontend): add horizontal oshi row of following accounts above home feed

### DIFF
--- a/services/frontend/workspace/src/app/page.tsx
+++ b/services/frontend/workspace/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Tabs, type TabItem } from "@/components/ui/tab";
 import { Button } from "@/components/ui/button";
 import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
 import { useFeed } from "@/modules/feed/hooks/useFeed";
+import { HomeOshiRow } from "@/modules/feed/components/HomeOshiRow";
 import { useProfile } from "@/modules/profile/hooks/useProfile";
 import type { FeedFilterValue } from "@/modules/feed/types";
 
@@ -82,6 +83,7 @@ export default function HomePage() {
 
   return (
     <main className="mx-auto flex max-w-xl flex-col bg-bg text-text-primary">
+      <HomeOshiRow />
       <header className="sticky top-0 z-10 bg-bg">
         <Tabs
           items={TAB_ITEMS}

--- a/services/frontend/workspace/src/modules/feed/components/HomeOshiRow.tsx
+++ b/services/frontend/workspace/src/modules/feed/components/HomeOshiRow.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { Avatar } from "@/components/ui/avatar";
+import { useFollowList } from "@/modules/social";
+
+export function HomeOshiRow() {
+  const { profiles, loading } = useFollowList();
+
+  if (loading && profiles.length === 0) return null;
+  if (profiles.length === 0) return null;
+
+  return (
+    <div className="flex gap-3 overflow-x-auto border-b border-divider px-4 py-3">
+      {profiles.map((p) => (
+        <Link
+          key={p.accountId}
+          href={`/u/${encodeURIComponent(p.username)}`}
+          className="flex w-16 shrink-0 flex-col items-center gap-1"
+        >
+          <Avatar
+            src={p.avatarUrl || undefined}
+            fallback={(p.displayName || "?").slice(0, 1)}
+            size="lg"
+          />
+          <span className="w-full truncate text-center text-xs text-text-secondary">
+            {p.displayName || p.username}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

rx-sns home の feed tabs 上にあるアバター横スクロール (推し row) を実装。フォロー中アカウントを横一列で表示し、タップで `/u/[username]` 遷移。

### Added
- `src/modules/feed/components/HomeOshiRow.tsx` — `useFollowList()` で取得した following profile を horizontal scroll。各アイテム = circle avatar + truncated displayName。フォロー 0 件 / loading 中 (初回) は何も描画しない (UI を占有しない)

### Changed
- `src/app/page.tsx` — `<HomeOshiRow />` を feed tabs の上、sticky header の外に mount。スクロールで一緒に流れる configuration (rx-sns 同等)

## Behavior

- フォロー先 1+ アカウントある: 横スクロール avatar 行を feed tab の上に表示
- フォロー先 0 件: 行ごと描画しない (rx-sns と同じ)
- アバター tap: `/u/[username]` プロフィール詳細

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline)
- tsc --noEmit: success

## Related
- 監査結果 rev2 P1 ギャップ
- 次の P1: Top header bell + cast 限定 drawer 出勤管理