### PR TITLE
feat(frontend): add notification bell to top header

### DIFF
--- a/services/frontend/workspace/src/components/shell/TopBar.tsx
+++ b/services/frontend/workspace/src/components/shell/TopBar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { Avatar } from "@/components/ui/avatar";
 import { useProfile } from "@/modules/profile/hooks";
+import { useUnreadCount } from "@/modules/notifications/hooks";
 
 interface TopBarProps {
   onAvatarClick: () => void;
@@ -9,6 +11,7 @@ interface TopBarProps {
 
 export function TopBar({ onAvatarClick }: TopBarProps) {
   const { profile } = useProfile();
+  const { count: unread } = useUnreadCount();
   const avatarUrl = profile?.avatarUrl || undefined;
   const fallback = (profile?.displayName || "?").slice(0, 1);
 
@@ -23,7 +26,18 @@ export function TopBar({ onAvatarClick }: TopBarProps) {
         <Avatar src={avatarUrl} fallback={fallback} size="sm" />
       </button>
       <div aria-hidden="true" />
-      <div className="w-8" aria-hidden="true" />
+      <Link
+        href="/notifications"
+        className="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-xl hover:bg-bg-secondary"
+        aria-label={unread > 0 ? `通知 (未読 ${unread})` : "通知"}
+      >
+        <span aria-hidden="true">🔔</span>
+        {unread > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 min-w-[1.125rem] rounded-full bg-accent px-1 text-center text-[10px] font-bold leading-tight text-white">
+            {unread > 99 ? "99+" : unread}
+          </span>
+        )}
+      </Link>
     </header>
   );
 }


### PR DESCRIPTION
## Summary

rx-sns top header の右側に bell icon があるのに合わせ、TopBar 右側の spacer を bell link に置換。`useUnreadCount` の数値を 上付き badge として表示する。

### Changed
- `src/components/shell/TopBar.tsx`
  - 右側 `<div className="w-8" />` spacer を `<Link href="/notifications">` の bell icon に置換
  - `useUnreadCount()` で未読件数取得、>0 なら右上 badge (99+ で省略)
  - aria-label を unread の有無で出し分け

## Behavior
- bell tap → `/notifications` 遷移
- 未読件数 1+ の場合、bell の右上に accent カラーの数値 badge
- 0 件の場合 badge 非表示、bell のみ

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline)
- tsc --noEmit: success

## Related
- 監査結果 rev2 P1 ギャップ (top header logo/bell の bell パート)
- 後続候補: cast 専用 drawer 出勤管理 item (要 destination page。/出勤管理 が未実装なので保留)