### PR TITLE
feat(footprints): F2 frontend data — 4 hooks + 4 BFFs + grpc client

### DIFF
--- a/services/frontend/workspace/src/app/api/footprints/list/route.ts
+++ b/services/frontend/workspace/src/app/api/footprints/list/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { footprintsClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+import { mapFootprintToView } from "@/modules/footprints/lib/mappers";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const limit = Number(req.nextUrl.searchParams.get("limit") || "20");
+    const cursor = req.nextUrl.searchParams.get("cursor") || "";
+
+    const res = await footprintsClient.listFootprints(
+      { limit, cursor },
+      { headers }
+    );
+    return NextResponse.json({
+      footprints: (res.footprints || []).map(mapFootprintToView),
+      nextCursor: res.nextCursor || "",
+      hasMore: !!res.hasMore,
+    });
+  } catch (error: unknown) {
+    return handleApiError(error, "ListFootprints");
+  }
+}

--- a/services/frontend/workspace/src/app/api/footprints/mark-read/route.ts
+++ b/services/frontend/workspace/src/app/api/footprints/mark-read/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { footprintsClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function POST(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    await footprintsClient.markRead({}, { headers });
+    return NextResponse.json({});
+  } catch (error: unknown) {
+    return handleApiError(error, "MarkFootprintsRead");
+  }
+}

--- a/services/frontend/workspace/src/app/api/footprints/unread-count/route.ts
+++ b/services/frontend/workspace/src/app/api/footprints/unread-count/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { footprintsClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const res = await footprintsClient.getUnreadCount({}, { headers });
+    return NextResponse.json({ count: res.count || 0 });
+  } catch (error: unknown) {
+    return handleApiError(error, "GetFootprintsUnreadCount");
+  }
+}

--- a/services/frontend/workspace/src/app/api/footprints/visit/route.ts
+++ b/services/frontend/workspace/src/app/api/footprints/visit/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { footprintsClient } from "@/lib/grpc";
+import { buildGrpcHeaders } from "@/lib/request";
+import { requireAuth, handleApiError } from "@/lib/api-helpers";
+
+export async function POST(req: NextRequest) {
+  try {
+    const authError = requireAuth(req);
+    if (authError) return authError;
+
+    const headers = buildGrpcHeaders(req.headers);
+    const body = await req.json();
+    const visitedAccountId = body?.visitedAccountId || "";
+
+    await footprintsClient.recordVisit({ visitedAccountId }, { headers });
+    return NextResponse.json({});
+  } catch (error: unknown) {
+    return handleApiError(error, "RecordVisit");
+  }
+}

--- a/services/frontend/workspace/src/lib/grpc.ts
+++ b/services/frontend/workspace/src/lib/grpc.ts
@@ -17,6 +17,7 @@ import { NotificationService } from "@/stub/notifications/v1/notification_servic
 import { BookmarkService } from "@/stub/bookmarks/v1/bookmark_service_pb";
 import { DiscoveryService } from "@/stub/discovery/v1/discovery_service_pb";
 import { MessagingService } from "@/stub/messaging/v1/messaging_service_pb";
+import { FootprintsService } from "@/stub/footprints/v1/footprints_service_pb";
 
 // In server environment (Next.js API Routes), we connect to Monolith directly.
 // Monolith is at 'http://monolith:9001' or 'http://localhost:9001' depending on Docker/Local.
@@ -64,3 +65,6 @@ export const discoveryClient = createClient(DiscoveryService, transport);
 
 // Messaging domain client (messaging.v1)
 export const messagingClient = createClient(MessagingService, transport);
+
+// Footprints domain client (footprints.v1)
+export const footprintsClient = createClient(FootprintsService, transport);

--- a/services/frontend/workspace/src/modules/footprints/hooks/index.ts
+++ b/services/frontend/workspace/src/modules/footprints/hooks/index.ts
@@ -1,0 +1,4 @@
+export { useFootprints } from "./useFootprints";
+export { useFootprintsUnreadCount } from "./useFootprintsUnreadCount";
+export { useRecordVisit } from "./useRecordVisit";
+export { markFootprintsRead } from "./markFootprintsRead";

--- a/services/frontend/workspace/src/modules/footprints/hooks/markFootprintsRead.ts
+++ b/services/frontend/workspace/src/modules/footprints/hooks/markFootprintsRead.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { authFetch } from "@/lib/auth/fetch";
+
+export async function markFootprintsRead(): Promise<void> {
+  try {
+    await authFetch("/api/footprints/mark-read", { method: "POST" });
+  } catch {
+    // SILENT: mark-read failure is non-critical
+  }
+}

--- a/services/frontend/workspace/src/modules/footprints/hooks/useFootprints.ts
+++ b/services/frontend/workspace/src/modules/footprints/hooks/useFootprints.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import useSWRInfinite from "swr/infinite";
+import { fetcher, getAuthToken } from "@/lib/swr";
+import type { PaginatedFootprintsResponse } from "../types";
+
+export function useFootprints() {
+  const token = getAuthToken();
+
+  const getKey = (
+    pageIndex: number,
+    prev: PaginatedFootprintsResponse | null
+  ): string | null => {
+    if (!token) return null;
+    if (prev && !prev.hasMore) return null;
+    const cursorQs =
+      pageIndex === 0
+        ? ""
+        : `?cursor=${encodeURIComponent(prev?.nextCursor || "")}`;
+    return `/api/footprints/list${cursorQs}`;
+  };
+
+  const { data, error, size, setSize, isLoading, isValidating, mutate } =
+    useSWRInfinite<PaginatedFootprintsResponse>(getKey, fetcher, {
+      revalidateOnFocus: false,
+    });
+
+  const pages = data || [];
+  const footprints = pages.flatMap((p) => p.footprints || []);
+  const hasMore =
+    pages.length > 0 ? !!pages[pages.length - 1].hasMore : false;
+
+  return {
+    footprints,
+    hasMore,
+    loading: isLoading || isValidating,
+    error,
+    loadMore: () => setSize(size + 1),
+    refresh: () => mutate(),
+  };
+}

--- a/services/frontend/workspace/src/modules/footprints/hooks/useFootprintsUnreadCount.ts
+++ b/services/frontend/workspace/src/modules/footprints/hooks/useFootprintsUnreadCount.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import useSWR from "swr";
+import { fetcher, getAuthToken } from "@/lib/swr";
+
+interface UnreadCountResponse {
+  count: number;
+}
+
+export function useFootprintsUnreadCount() {
+  const token = getAuthToken();
+  const { data, error, isLoading, mutate } = useSWR<UnreadCountResponse>(
+    token ? "/api/footprints/unread-count" : null,
+    fetcher,
+    { refreshInterval: 30000, revalidateOnFocus: false }
+  );
+  return {
+    count: data?.count ?? 0,
+    loading: isLoading,
+    error,
+    refresh: () => mutate(),
+  };
+}

--- a/services/frontend/workspace/src/modules/footprints/hooks/useRecordVisit.ts
+++ b/services/frontend/workspace/src/modules/footprints/hooks/useRecordVisit.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useCallback } from "react";
+import { authFetch } from "@/lib/auth/fetch";
+
+export function useRecordVisit() {
+  return useCallback(async (visitedAccountId: string): Promise<void> => {
+    try {
+      await authFetch("/api/footprints/visit", {
+        method: "POST",
+        body: { visitedAccountId },
+      });
+    } catch {
+      // SILENT: visit recording failure should not affect UX
+    }
+  }, []);
+}

--- a/services/frontend/workspace/src/modules/footprints/index.ts
+++ b/services/frontend/workspace/src/modules/footprints/index.ts
@@ -1,0 +1,6 @@
+export * from "./hooks";
+export type {
+  FootprintView,
+  FootprintVisitorView,
+  PaginatedFootprintsResponse,
+} from "./types";

--- a/services/frontend/workspace/src/modules/footprints/lib/mappers.ts
+++ b/services/frontend/workspace/src/modules/footprints/lib/mappers.ts
@@ -1,0 +1,24 @@
+import type { Footprint as FootprintProto } from "@/stub/footprints/v1/footprints_service_pb";
+import type { FootprintView } from "../types";
+
+export function mapFootprintToView(proto: FootprintProto): FootprintView {
+  const visitor = proto.visitor;
+  const lastVisited = proto.lastVisitedAt;
+  const lastVisitedAtIso = lastVisited
+    ? new Date(
+        Number(lastVisited.seconds) * 1000 +
+          Math.floor(Number(lastVisited.nanos) / 1_000_000)
+      ).toISOString()
+    : "";
+
+  return {
+    visitor: {
+      accountId: visitor?.accountId || "",
+      username: visitor?.username || "",
+      displayName: visitor?.displayName || "",
+      avatarUrl: visitor?.avatarUrl || null,
+    },
+    lastVisitedAt: lastVisitedAtIso,
+    isUnread: !!proto.isUnread,
+  };
+}

--- a/services/frontend/workspace/src/modules/footprints/types.ts
+++ b/services/frontend/workspace/src/modules/footprints/types.ts
@@ -1,0 +1,21 @@
+// View shapes for footprints module.
+// Visitor is the rx-sns-equivalent: "誰が私を訪問したか" (incoming-direction).
+
+export interface FootprintVisitorView {
+  accountId: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+}
+
+export interface FootprintView {
+  visitor: FootprintVisitorView;
+  lastVisitedAt: string; // ISO8601
+  isUnread: boolean;
+}
+
+export interface PaginatedFootprintsResponse {
+  footprints: FootprintView[];
+  nextCursor: string;
+  hasMore: boolean;
+}


### PR DESCRIPTION
## Summary

Footprints F2 frontend data layer。F1 monolith (#728) で公開された 4 RPC を frontend hook + BFF にラップ。

### Added (12 files)

**Module**
- `src/modules/footprints/types.ts` — `FootprintView`, `FootprintVisitorView`, `PaginatedFootprintsResponse`
- `src/modules/footprints/lib/mappers.ts` — proto Footprint → view (`profile.v1.Profile` の accountId/username/displayName/avatarUrl + Timestamp ISO 化)
- `src/modules/footprints/hooks/useFootprints.ts` — useSWRInfinite cursor 一覧
- `src/modules/footprints/hooks/useFootprintsUnreadCount.ts` — useSWR + 30s polling
- `src/modules/footprints/hooks/useRecordVisit.ts` — fire-and-forget POST、失敗は silent
- `src/modules/footprints/hooks/markFootprintsRead.ts` — POST mark-read
- `src/modules/footprints/hooks/index.ts` + `src/modules/footprints/index.ts` — barrel

**BFFs**
- `POST /api/footprints/visit` — `{visitedAccountId}` body
- `GET /api/footprints/list?limit=&cursor=`
- `GET /api/footprints/unread-count`
- `POST /api/footprints/mark-read`

### Changed

- `src/lib/grpc.ts` — `FootprintsService` import + `footprintsClient` export (messagingClient の次)

## Verification

- tsc --noEmit: clean
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline 維持、footprints files に新規 issue なし)
- Profile field names: `Profile` の accountId/username/displayName/avatarUrl を `src/stub/profile/v1/service_pb.ts` で実体確認
- authFetch: `{ method, body, requireAuth, cache }` signature を `src/lib/auth/fetch.ts` で確認

## Stack

- Spec: docs/superpowers/specs/2026-06-18-footprints-design.md (#727)
- F1: monolith (#728)
- **F2: this PR**
- F3: frontend UI (page + visit trigger + drawer badge) — next