### PR TITLE
feat(footprints): F3 frontend UI — page + visit trigger + drawer badge

### DIFF
--- a/services/frontend/workspace/src/app/footprints/page.tsx
+++ b/services/frontend/workspace/src/app/footprints/page.tsx
@@ -1,9 +1,45 @@
 "use client";
 
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { useFootprints, useFootprintsUnreadCount, markFootprintsRead } from "@/modules/footprints";
+import { FootprintRow } from "@/modules/footprints/components/FootprintRow";
+
 export default function FootprintsPage() {
+  const { footprints, hasMore, loading, error, loadMore } = useFootprints();
+  const unreadCount = useFootprintsUnreadCount();
+
+  useEffect(() => {
+    markFootprintsRead().then(() => unreadCount.refresh());
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
-    <main className="mx-auto max-w-xl p-6 text-center text-text-secondary">
-      足跡機能は準備中です。
+    <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
+      <h1 className="px-4 pb-2 pt-4 text-xl font-bold">足跡</h1>
+
+      {loading && footprints.length === 0 && (
+        <p className="px-4 py-8 text-center text-text-secondary">読み込み中…</p>
+      )}
+      {error && (
+        <p className="px-4 py-8 text-center text-text-danger">読み込みに失敗しました</p>
+      )}
+      {!loading && footprints.length === 0 && !error && (
+        <p className="px-4 py-8 text-center text-text-secondary">
+          あなたを訪問した人はまだいません。
+        </p>
+      )}
+
+      {footprints.map((f) => (
+        <FootprintRow key={f.visitor.accountId} footprint={f} />
+      ))}
+
+      {hasMore && (
+        <div className="flex justify-center px-4 py-6">
+          <Button variant="secondary" size="sm" onClick={loadMore} disabled={loading}>
+            {loading ? "読み込み中…" : "もっと見る"}
+          </Button>
+        </div>
+      )}
     </main>
   );
 }

--- a/services/frontend/workspace/src/app/u/[username]/page.tsx
+++ b/services/frontend/workspace/src/app/u/[username]/page.tsx
@@ -1,17 +1,28 @@
 "use client";
 
+import { useEffect } from "react";
 import { useParams } from "next/navigation";
 import { usePublicProfile } from "@/modules/profile/hooks";
 import { ProfileHeader } from "@/modules/profile/components/ProfileHeader";
 import { FollowButton, BlockButton, useSocialCounts } from "@/modules/social";
 import { StartChatButton } from "@/modules/messaging";
 import { ProfileContentTabs } from "@/modules/post/components/ProfileContentTabs";
+import { useRecordVisit } from "@/modules/footprints";
+import { useAuthStore, selectUserId } from "@/stores/authStore";
 
 export default function PublicProfilePage() {
   const params = useParams<{ username: string }>();
   const username = typeof params.username === "string" ? params.username : "";
   const { profile, loading, error } = usePublicProfile(username || null);
   const counts = useSocialCounts(profile?.accountId);
+  const viewerId = useAuthStore(selectUserId);
+  const recordVisit = useRecordVisit();
+
+  useEffect(() => {
+    if (!viewerId || !profile?.accountId) return;
+    if (viewerId === profile.accountId) return;
+    recordVisit(profile.accountId);
+  }, [viewerId, profile?.accountId, recordVisit]);
 
   if (loading) {
     return <main className="mx-auto max-w-xl p-6 text-text-secondary">読み込み中…</main>;

--- a/services/frontend/workspace/src/components/shell/Drawer.tsx
+++ b/services/frontend/workspace/src/components/shell/Drawer.tsx
@@ -8,13 +8,14 @@ import { useProfile } from "@/modules/profile/hooks";
 import { useSocialCounts } from "@/modules/social";
 import { useUnreadCount } from "@/modules/notifications/hooks";
 import { useTotalUnread } from "@/modules/messaging";
+import { useFootprintsUnreadCount } from "@/modules/footprints";
 import { useAuthStore } from "@/stores/authStore";
 
 const NAV_ITEMS = [
   { path: "__profile__", label: "プロフィール", icon: "👤" },
   { path: "/search", label: "検索", icon: "🔍" },
   { path: "/notifications", label: "通知", icon: "🔔", badgeKey: "unread" as const },
-  { path: "/footprints", label: "足跡", icon: "👣" },
+  { path: "/footprints", label: "足跡", icon: "👣", badgeKey: "footprints_unread" as const },
   { path: "/messages", label: "メッセージ", icon: "💬", badgeKey: "messaging_unread" as const },
   { path: "/bookmarks", label: "ブックマーク", icon: "🔖" },
   { path: "/oshi", label: "推し！", icon: "⭐" },
@@ -33,6 +34,7 @@ export function Drawer({ open, onClose }: DrawerProps) {
   const { followingCount, followersCount } = useSocialCounts(profile?.accountId);
   const { count: unread } = useUnreadCount();
   const { count: msgUnread } = useTotalUnread();
+  const { count: footprintsUnread } = useFootprintsUnreadCount();
   const clearTokens = useAuthStore((s) => s.clearTokens);
 
   useEffect(() => {
@@ -85,6 +87,7 @@ export function Drawer({ open, onClose }: DrawerProps) {
             const badgeCount =
               item.badgeKey === "unread" ? unread :
               item.badgeKey === "messaging_unread" ? msgUnread :
+              item.badgeKey === "footprints_unread" ? footprintsUnread :
               0;
             const showBadge = badgeCount > 0;
             const href =

--- a/services/frontend/workspace/src/modules/footprints/components/FootprintRow.tsx
+++ b/services/frontend/workspace/src/modules/footprints/components/FootprintRow.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { Avatar } from "@/components/ui/avatar";
+import { formatTimeAgo } from "@/lib/utils/date";
+import type { FootprintView } from "@/modules/footprints/types";
+
+export interface FootprintRowProps {
+  footprint: FootprintView;
+}
+
+export function FootprintRow({ footprint }: FootprintRowProps) {
+  const { visitor, lastVisitedAt, isUnread } = footprint;
+  const href = visitor.username ? `/u/${encodeURIComponent(visitor.username)}` : "#";
+
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-3 border-b border-divider px-4 py-3 hover:bg-bg-surface/50"
+    >
+      {isUnread && (
+        <span aria-hidden="true" className="-ml-2 h-12 w-0.5 rounded-full bg-gradient-brand" />
+      )}
+      <Avatar
+        src={visitor.avatarUrl || undefined}
+        fallback={(visitor.displayName || "?").slice(0, 1)}
+        size="md"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-bold text-text-primary">{visitor.displayName || "—"}</p>
+        <p className="truncate text-sm text-text-secondary">@{visitor.username || "—"}</p>
+      </div>
+      <span className="text-xs text-text-muted">
+        {lastVisitedAt ? formatTimeAgo(lastVisitedAt) : ""}
+      </span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

Footprints F3 frontend UI 実装、F0-F3 ロードマップ完走。Tier 3 pattern と同様 monolith → data → UI の縦スライス。

### Added
- `src/modules/footprints/components/FootprintRow.tsx` — 行: avatar + name + handle + 相対時刻 + 未読 stripe (gradient-brand 左 0.5px)、tap で `/u/[username]`

### Changed
- `src/app/footprints/page.tsx` — "準備中" stub から実装に置換。`useFootprints` で cursor pagination 表示、mount 時に `markFootprintsRead()` を fire して unread badge クリア
- `src/app/u/[username]/page.tsx` — `useRecordVisit` を useEffect 内で fire-and-forget。自己訪問 / 未認証は skip
- `src/components/shell/Drawer.tsx` — 足跡 nav item に `badgeKey: "footprints_unread"` 追加、`useFootprintsUnreadCount` を bind

## Behavior

- 他人プロフィール訪問 → `POST /api/footprints/visit` (silent failure)
- `/footprints` mount → ListFootprints + 自動 markRead → drawer badge 0 化
- drawer 足跡 item に未読件数 badge (99+ で省略、accent gradient)

## Verification
- pnpm build: success
- pnpm lint: 5 errors / 7 warnings (baseline)
- tsc --noEmit: success

## Stack
- Spec: docs/superpowers/specs/2026-06-18-footprints-design.md (#727)
- F1 monolith: #728
- F2 frontend data: #729
- **F3 frontend UI: this PR — Footprints roadmap 完走**

## Next
監査 rev2 残ギャップ: Settings 通知設定/外観 tabs (P2)、Search role chips (P2)。F1-F3 完走後の cleanup audit (#94 含む) を予告通り実施。