### PR TITLE
fix(social): use repo transaction in BlockRepository#block

### DIFF
--- a/services/monolith/workspace/slices/social/repositories/block_repository.rb
+++ b/services/monolith/workspace/slices/social/repositories/block_repository.rb
@@ -15,7 +15,7 @@ module Social
       # --- Mutations ----
 
       def block(blocker_id:, blocked_id:)
-        rom.gateways[:default].transaction do
+        transaction do
           existing = blocks.where(blocker_id: blocker_id, blocked_id: blocked_id).one
           unless existing
             blocks.changeset(:create,


### PR DESCRIPTION
## Summary

`Social::Repositories::BlockRepository#block` が `rom.gateways[:default].transaction` を呼んでいたが `rom` method は parent class (`Hanami::DB::Repo` / `ROM::Repository::Root`) に存在せず、production で `block` RPC を呼ぶと `NoMethodError: undefined method 'rom'` で必ず爆発していた。

### Root cause

block_repository.rb:18 のみ `rom.gateways[:default].transaction do` パターンを使用。他の repo (offer / profile / messaging 等) は全て bare `transaction do` で transaction を開く。grep 結果: `rom.gateways` の出現は monolith 全体でこの 1 箇所のみ。

### Discovery

Footprints F1 (#728) RecordVisit spec を書く際、spec で `block_repo.block(...)` を呼んだら NoMethodError で fail。回避策として `relations.blocks.dataset.insert` で直接挿入し spec を通したが、本体修正を [#94 task として記録](#) → 本 PR で清算。

### Fix

1 行: `rom.gateways[:default].transaction do` → `transaction do`

### Verification (local)

```bash
repo = Social::Slice["repositories.block_repository"]
repo.block(blocker_id: a, blocked_id: b)   # PASS, blocks row inserted
repo.blocked?(blocker_id: a, blocked_id: b)  # => true
repo.unblock(blocker_id: a, blocked_id: b)
repo.blocked?(blocker_id: a, blocked_id: b)  # => false
```

production smoke OK。

### Affected callers (now functional again)

- `Social::Grpc::BlockHandler#block` RPC → frontend `socialBlockClient.block(...)` 経路、UI の BlockButton tap
- `Social::UseCases::BlockUser` 経路の全 caller

## Context

cleanup audit (2026-06-18) で発見した最優先 P0 修正。Tier 3 → Footprints 完走と並行して走らせる予定の cleanup PR シリーズ 1 件目。後続候補:
- 旧 portfolio.v1 CastHandler/GuestHandler 撤去 (P5 で profile.v1 統合済)
- Offer slice 撤去 (commerce dimension 2026-05-29 drop 済の名残)
- portfolio__profiles 旧テーブル orphan 調査

これらは frontend usage 検証後別 PR で。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal implementation of transaction handling in block management.

**Note:** This update is an internal optimization with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->