### PR TITLE
feat(post): add comment reply composer with parent_id

### DIFF
--- a/services/frontend/workspace/src/modules/post/components/CommentList.tsx
+++ b/services/frontend/workspace/src/modules/post/components/CommentList.tsx
@@ -7,6 +7,7 @@ import { formatTimeAgo } from "@/lib/utils/date";
 import { useComments } from "@/modules/post/hooks/useComments";
 import { useDeleteComment } from "@/modules/post/hooks/useDeleteComment";
 import { ReplyList } from "./ReplyList";
+import { ReplyComposer } from "./ReplyComposer";
 import { useAuthStore, selectUserId } from "@/stores/authStore";
 
 interface CommentListProps {
@@ -18,6 +19,7 @@ export function CommentList({ postId }: CommentListProps) {
   const { comments, hasMore, loading, error, loadMore } = useComments(postId);
   const { deleteComment, submitting: deleting } = useDeleteComment(postId);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [replying, setReplying] = useState<string | null>(null);
 
   if (loading && comments.length === 0) {
     return <p className="px-4 py-4 text-text-secondary">読み込み中…</p>;
@@ -54,6 +56,13 @@ export function CommentList({ postId }: CommentListProps) {
                 </div>
                 <p className="mt-1 whitespace-pre-wrap text-text-primary">{c.content}</p>
                 <div className="mt-2 flex items-center gap-4 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => setReplying((cur) => (cur === c.id ? null : c.id))}
+                    className="text-text-secondary hover:text-text-primary"
+                  >
+                    {replying === c.id ? "返信を閉じる" : "返信する"}
+                  </button>
                   {c.repliesCount > 0 && (
                     <button
                       type="button"
@@ -79,6 +88,17 @@ export function CommentList({ postId }: CommentListProps) {
                 </div>
               </div>
             </article>
+            {replying === c.id && (
+              <ReplyComposer
+                postId={postId}
+                parentId={c.id}
+                onCancel={() => setReplying(null)}
+                onSubmitted={() => {
+                  setReplying(null);
+                  setExpanded((prev) => ({ ...prev, [c.id]: true }));
+                }}
+              />
+            )}
             {isExpanded && <ReplyList postId={postId} commentId={c.id} />}
           </div>
         );

--- a/services/frontend/workspace/src/modules/post/components/ReplyComposer.tsx
+++ b/services/frontend/workspace/src/modules/post/components/ReplyComposer.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useAddComment } from "@/modules/post/hooks/useAddComment";
+
+interface ReplyComposerProps {
+  postId: string;
+  parentId: string;
+  onCancel: () => void;
+  onSubmitted: () => void;
+}
+
+const MAX_LENGTH = 1000;
+
+export function ReplyComposer({ postId, parentId, onCancel, onSubmitted }: ReplyComposerProps) {
+  const [content, setContent] = useState("");
+  const { addComment, submitting, error } = useAddComment(postId);
+
+  const trimmed = content.trim();
+  const overLimit = content.length > MAX_LENGTH;
+  const canSubmit = !submitting && trimmed.length > 0 && !overLimit;
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!canSubmit) return;
+      try {
+        await addComment(content, parentId);
+        setContent("");
+        onSubmitted();
+      } catch {
+        // error は hook 内 state、UI で表示
+      }
+    },
+    [canSubmit, content, parentId, addComment, onSubmitted]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="border-b border-divider py-3 pl-12 pr-4">
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="返信を書く"
+        rows={2}
+        aria-label="返信内容"
+        autoFocus
+      />
+      <div className="mt-2 flex items-center justify-between gap-3">
+        <span
+          className={`text-xs ${overLimit ? "text-error" : "text-text-muted"}`}
+          aria-live="polite"
+        >
+          {content.length}/{MAX_LENGTH}
+        </span>
+        <div className="flex gap-2">
+          <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={submitting}>
+            キャンセル
+          </Button>
+          <Button type="submit" variant="primary" size="sm" disabled={!canSubmit}>
+            {submitting ? "送信中…" : "返信"}
+          </Button>
+        </div>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm text-error" role="alert">
+          返信送信に失敗しました
+        </p>
+      )}
+    </form>
+  );
+}

--- a/services/frontend/workspace/src/modules/post/hooks/useAddComment.ts
+++ b/services/frontend/workspace/src/modules/post/hooks/useAddComment.ts
@@ -10,7 +10,7 @@ export function useAddComment(postId: string | null | undefined) {
   const [error, setError] = useState<Error | null>(null);
 
   const addComment = useCallback(
-    async (content: string) => {
+    async (content: string, parentId?: string) => {
       if (!postId) return;
       const trimmed = content.trim();
       if (trimmed.length === 0) return;
@@ -20,14 +20,27 @@ export function useAddComment(postId: string | null | undefined) {
       try {
         await authFetch(`/api/posts/${encodeURIComponent(postId)}/comments`, {
           method: "POST",
-          body: { content: trimmed },
+          body: { content: trimmed, parentId: parentId || "" },
         });
-        // Refresh: comment list (useSWRInfinite cache keys start with this path) + post detail (commentsCount)
-        mutate(
-          (key) =>
-            typeof key === "string" &&
-            key.startsWith(`/api/posts/${encodeURIComponent(postId)}/comments`)
-        );
+        if (parentId) {
+          // Refresh reply list for this parent + top-level comment row (repliesCount bump).
+          const repliesPrefix = `/api/posts/${encodeURIComponent(postId)}/comments/${encodeURIComponent(parentId)}/replies`;
+          mutate(
+            (key) => typeof key === "string" && key.startsWith(repliesPrefix)
+          );
+          mutate(
+            (key) =>
+              typeof key === "string" &&
+              key.startsWith(`/api/posts/${encodeURIComponent(postId)}/comments`) &&
+              !key.includes("/replies")
+          );
+        } else {
+          mutate(
+            (key) =>
+              typeof key === "string" &&
+              key.startsWith(`/api/posts/${encodeURIComponent(postId)}/comments`)
+          );
+        }
         mutate(`/api/posts/${encodeURIComponent(postId)}`);
       } catch (e) {
         setError(e as Error);


### PR DESCRIPTION
## Summary

Comments スライス (#704/#705/#706) で deferred としていた reply composer (parent_id 指定 CommentComposer) を実装。各コメント行に「返信する」action 追加 → 展開で ReplyComposer 表示 → 送信で parent_id 付き AddComment + ReplyList 自動 refresh。

### Added
- `src/modules/post/components/ReplyComposer.tsx` — parent_id 必須、autoFocus、キャンセル + 返信 button 2 つ

### Changed
- `src/modules/post/hooks/useAddComment.ts` — `addComment(content, parentId?)` のシグネチャに拡張。parent_id 有時:
  - `/api/posts/[id]/comments/[parentId]/replies*` cache 無効化 (ReplyList 自動 refresh)
  - 親コメント行 cache も無効化 (`repliesCount` bump 反映)
- `src/modules/post/components/CommentList.tsx` — 各コメントに「返信する」action 追加、`<ReplyComposer>` を `<ReplyList>` の上に出す。送信成功で自動的に `expanded[c.id] = true` にして新規返信が見える状態に

### Behavior
- 「返信する」tap → 同コメント直下に composer 展開 (autoFocus)
- 別コメントで「返信する」tap → 前の composer は閉じ新しい方を開く
- 送信 → 自動 close + ReplyList が展開状態に
- ReplyList の cursor pagination は変更なし

## Verification
- pnpm build: success
- pnpm lint: 1 error / 5 warnings (baseline 維持)
- pnpm tsc: clean

## Discovery context
discovery slice 完成後に「reply composer は polish 余地」と memory に記録されていた deferred 項目。BFF (`POST /api/posts/[id]/comments`) は元々 `parentId` を受け取れる状態で、frontend 側だけ未対応だった。