### PR TITLE
feat(notifications): tap-through navigation to target resource

### DIFF
--- a/services/frontend/workspace/src/app/notifications/page.tsx
+++ b/services/frontend/workspace/src/app/notifications/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useNotifications, NotificationType } from "@/modules/notifications";
@@ -24,13 +25,40 @@ function describe(n: NotificationView): string {
   }
 }
 
+// Returns the destination URL for a notification tap, or null when no
+// deep-link is possible (e.g. COMMENT/REPLY where target_resource_id is the
+// comment_id and the post_id is not on the notification view).
+function targetHref(n: NotificationView): string | null {
+  switch (n.type) {
+    case NotificationType.LIKE:
+      return `/posts/${encodeURIComponent(n.targetResourceId)}`;
+    case NotificationType.FOLLOW_REQUEST:
+      return "/settings/follow-requests";
+    case NotificationType.FOLLOW_APPROVED:
+      return n.latestActor?.username
+        ? `/u/${encodeURIComponent(n.latestActor.username)}`
+        : null;
+    default:
+      return null;
+  }
+}
+
 function formatDate(iso: string): string {
   if (!iso) return "";
   return new Date(iso).toLocaleString("ja-JP");
 }
 
 export default function NotificationsPage() {
+  const router = useRouter();
   const { notifications, hasMore, unreadCount, loading, loadMore, markRead } = useNotifications();
+
+  const handleClick = (n: NotificationView) => {
+    if (!n.readAt) {
+      markRead(n.id).catch(() => {});
+    }
+    const href = targetHref(n);
+    if (href) router.push(href);
+  };
 
   return (
     <main className="mx-auto max-w-xl bg-bg pb-10 text-text-primary">
@@ -52,7 +80,7 @@ export default function NotificationsPage() {
           <button
             key={n.id}
             type="button"
-            onClick={() => markRead(n.id)}
+            onClick={() => handleClick(n)}
             className={`flex w-full items-start gap-3 border-b border-border px-4 py-3 text-left hover:bg-bg-secondary ${
               isUnread ? "bg-bg-secondary/50" : ""
             }`}


### PR DESCRIPTION
## Summary

Notifications spec で deferred 扱いだった「target_resource ナビゲート」を実装。/notifications の各通知タップで markRead に加え対象 URL へ router.push。

### Behavior

| 通知タイプ | 遷移先 |
|---|---|
| LIKE | \`/posts/[targetResourceId]\` (target = post_id) |
| FOLLOW_REQUEST | \`/settings/follow-requests\` |
| FOLLOW_APPROVED | \`/u/[latestActor.username]\` |
| COMMENT / REPLY | 遷移なし (target = comment_id しか無い、post_id 取得には proto 拡張要、別 PR) |

### Changed

- `src/app/notifications/page.tsx`
  - `useRouter` 取得 + `handleClick(n)` で `if (!n.readAt) markRead` + `targetHref(n)` 取得 + `router.push`
  - `targetHref` ヘルパー: 通知タイプ別の URL 算出、不可能時 `null`

## Verification
- pnpm build: success
- pnpm tsc: clean
- pnpm lint: 1 error / 5 warnings (baseline 維持)

## Discovery context
notifications slice 完成時 (#691-#696) に "target_resource ナビゲート" として deferred。frontend 1 ファイル変更で着地。COMMENT/REPLY の post_id 解決は別建て。