### PR TITLE
test(profile): provide explicit id in cast_repository_spec schedule fixtures

### DIFF
--- a/services/monolith/workspace/spec/slices/profile/repositories/cast_repository_spec.rb
+++ b/services/monolith/workspace/spec/slices/profile/repositories/cast_repository_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Profile::Repositories::CastRepository", type: :database do
       schedule_repo = Hanami.app.slices[:profile]["relations.schedules"]
       # Use fixed time range that works regardless of current time (00:00 - 23:59)
       schedule_repo.changeset(:create, {
+        id: SecureRandom.uuid_v7,
         cast_user_id: cast_with_schedule.user_id,
         date: Date.today,
         start_time: "00:00",
@@ -72,6 +73,7 @@ RSpec.describe "Profile::Repositories::CastRepository", type: :database do
       schedule_repo = Hanami.app.slices[:profile]["relations.schedules"]
       # Use fixed time range that works regardless of current time (00:00 - 23:59)
       schedule_repo.changeset(:create, {
+        id: SecureRandom.uuid_v7,
         cast_user_id: online_cast.user_id,
         date: Date.today,
         start_time: "00:00",
@@ -136,6 +138,7 @@ RSpec.describe "Profile::Repositories::CastRepository", type: :database do
         schedule_repo = Hanami.app.slices[:profile]["relations.schedules"]
         # Use fixed time range that works regardless of current time (00:00 - 23:59)
         schedule_repo.changeset(:create, {
+          id: SecureRandom.uuid_v7,
           cast_user_id: online_cast.user_id,
           date: Date.today,
           start_time: "00:00",


### PR DESCRIPTION
## Summary

cleanup audit Phase 2 (#733) で flag した pre-existing test failures (4 件) を清算。`spec/slices/profile/repositories/cast_repository_spec.rb` の online-status fixture 群が `schedule_repo.changeset(:create, {...}).commit` で `id` を省略していたが、`offer__schedules` テーブルに DB 側の id default がなく `PG::NotNullViolation` で失敗していた。

### Fix

3 箇所の `schedule_repo.changeset(:create, {...})` に `id: SecureRandom.uuid_v7` を追加 (`is_online?` x2 + `online_cast_ids` x1 + `list_casts_with_filters status:online` x1)。

`relations/schedules.rb` には "Read-only relation for online status queries / Write operations were removed in 2026-05-29 commerce dimension drop" コメントが入っているが、spec の fixture seed では writes が依然必要。代替方法は DB に id default を追加することだが migration の方が変更が大きいので spec 側の補完にとどめる。

### Verification

\`\`\`
$ bundle exec rspec spec/slices/profile/repositories/cast_repository_spec.rb
19 examples, 0 failures
\`\`\`

Phase 2 で 152 examples, 4 failures だった profile + post + footprints 全 suite が 156 examples, 0 failures になる。

## Discovery context

Phase 2 cleanup PR (#733) で「pre-existing 4 failures、本 PR 由来でない」と git stash 往復で確認したもの。task tracked at backlog #98、本 PR で清算。