### PR TITLE
feat(notifications): gate emit and drawer badge by notification preferences

### DIFF
--- a/services/frontend/workspace/src/components/shell/Drawer.tsx
+++ b/services/frontend/workspace/src/components/shell/Drawer.tsx
@@ -9,6 +9,7 @@ import { useSocialCounts } from "@/modules/social";
 import { useUnreadCount } from "@/modules/notifications/hooks";
 import { useTotalUnread } from "@/modules/messaging";
 import { useFootprintsUnreadCount } from "@/modules/footprints";
+import { useNotificationPreferences } from "@/modules/notifications/hooks";
 import { useAuthStore } from "@/stores/authStore";
 
 const NAV_ITEMS = [
@@ -35,7 +36,9 @@ export function Drawer({ open, onClose }: DrawerProps) {
   const { count: unread } = useUnreadCount();
   const { count: msgUnread } = useTotalUnread();
   const { count: footprintsUnread } = useFootprintsUnreadCount();
+  const { preferences } = useNotificationPreferences();
   const clearTokens = useAuthStore((s) => s.clearTokens);
+  const footprintsBadgeEnabled = preferences?.footprintUnreadBadge !== false;
 
   useEffect(() => {
     if (!open) return;
@@ -87,7 +90,7 @@ export function Drawer({ open, onClose }: DrawerProps) {
             const badgeCount =
               item.badgeKey === "unread" ? unread :
               item.badgeKey === "messaging_unread" ? msgUnread :
-              item.badgeKey === "footprints_unread" ? footprintsUnread :
+              item.badgeKey === "footprints_unread" ? (footprintsBadgeEnabled ? footprintsUnread : 0) :
               0;
             const showBadge = badgeCount > 0;
             const href =

--- a/services/monolith/workspace/slices/notifications/use_cases/emit.rb
+++ b/services/monolith/workspace/slices/notifications/use_cases/emit.rb
@@ -9,7 +9,22 @@ module Notifications
     # Callers (cross-slice from Post / Social use_cases) should NOT rescue or branch
     # on the return value -- emit must never disrupt the source action.
     class Emit
-      include Notifications::Deps[notification_repo: "repositories.notification_repository"]
+      include Notifications::Deps[
+        notification_repo: "repositories.notification_repository",
+        get_preferences: "use_cases.get_preferences"
+      ]
+
+      # Mapping notification type → preferences toggle field.
+      # COMMENT maps to `post` because rx-sns lacks a dedicated comment-on-post
+      # toggle; ポスト is the closest equivalent. FOLLOW_REQUEST + FOLLOW_APPROVED
+      # share the single `follow` toggle.
+      PREFERENCE_FIELD_BY_TYPE = {
+        "like" => :like,
+        "comment" => :post,
+        "reply" => :reply,
+        "follow_request" => :follow,
+        "follow_approved" => :follow
+      }.freeze
 
       # @param recipient_id [String] account_id receiving the notification
       # @param type [String] one of: 'like' | 'comment' | 'reply' | 'follow_request' | 'follow_approved'
@@ -21,6 +36,7 @@ module Notifications
         return nil if recipient_id.to_s == actor_id.to_s
 
         return nil if block_repo.blocked?(blocker_id: recipient_id, blocked_id: actor_id)
+        return nil unless type_enabled_for?(recipient_id, type)
 
         notification_repo.emit(
           recipient_id: recipient_id,
@@ -34,6 +50,14 @@ module Notifications
       end
 
       private
+
+      def type_enabled_for?(recipient_id, type)
+        field = PREFERENCE_FIELD_BY_TYPE[type.to_s]
+        return true unless field  # unknown type → fail open (don't suppress)
+
+        prefs = get_preferences.call(account_id: recipient_id)
+        prefs[field] != false
+      end
 
       def block_repo
         @block_repo ||= Social::Slice["repositories.block_repository"]


### PR DESCRIPTION
## Summary

#738 で persist 化した notification preferences に実効性を与える。Emit に per-type gating + Drawer の足跡 badge を per-account preference でゲート。

### Backend
`slices/notifications/use_cases/emit.rb`:
- Deps に `get_preferences` 追加
- `PREFERENCE_FIELD_BY_TYPE` mapping:
  - `like` → preferences.like
  - `comment` → preferences.post (rx-sns には dedicated comment toggle 無いので post に proxy mapping、コメント付与）
  - `reply` → preferences.reply
  - `follow_request` / `follow_approved` → preferences.follow
- `type_enabled_for?(recipient_id, type)` で recipient の preferences 取得、対応フィールドが false なら emit skip。unknown type は fail-open

### Frontend
`src/components/shell/Drawer.tsx`:
- `useNotificationPreferences()` を読む
- `footprintUnreadBadge !== false` のときのみ 足跡 nav に badge 数値を流す。false 時は 0 = badge 非表示

## Behavior

| シナリオ | Before | After |
|---|---|---|
| 既定 (preferences 行なし) | 全 type emit | 全 type emit (DEFAULT_PREFERENCES = all true) |
| preferences.like = false | like emit され続ける | like emit skip |
| preferences.post = false | comment emit され続ける | comment emit skip |
| preferences.follow = false | follow_request/approved emit | 両方 skip |
| preferences.footprint_unread_badge = false | 足跡 badge 表示 | 足跡 badge 非表示 |

## Verification (backend smoke)
- default like → emitted
- like-off + like → nil (skip)
- like-off + comment → emitted (comment は post field、影響なし)
- post-off + comment → nil (skip)

## Frontend
- tsc clean / pnpm build success / lint baseline 維持 (1e/5w)

## Stack
- #738 で preferences 永続化、本 PR で gating
- Defer (本 PR 範囲外): push provider 接続 (push_enabled は currently UI のみ)