### PR TITLE
chore(codegen): pin grpc-tools 1.76.0 and add repo-root codegen wrapper

### DIFF
--- a/bin/codegen
+++ b/bin/codegen
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Regenerate Ruby + TypeScript proto stubs from `proto/`.
+#
+# Why this exists: the monolith and the frontend each have their own codegen
+# entry point (`services/monolith/workspace/bin/codegen` for Ruby via buf +
+# grpc-tools, `pnpm proto:gen` inside `services/frontend/workspace` for TS via
+# @bufbuild/protoc-gen-es). After a proto change, both must run, otherwise the
+# Ruby and TS stubs drift. This wrapper runs them in order from the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -z "${NODE_OPTIONS+x}" ]; then
+  # Pass through.
+  RUN_PREFIX=""
+else
+  # The cmux harness sets NODE_OPTIONS for its own preload; unset for tool runs.
+  RUN_PREFIX="env -u NODE_OPTIONS"
+fi
+
+echo "[codegen] regenerating Ruby stubs (monolith)..."
+(cd services/monolith/workspace && $RUN_PREFIX bundle exec ./bin/codegen)
+
+echo "[codegen] regenerating TypeScript stubs (frontend)..."
+(cd services/frontend/workspace && $RUN_PREFIX pnpm proto:gen)
+
+echo "[codegen] done."

--- a/services/monolith/workspace/Gemfile
+++ b/services/monolith/workspace/Gemfile
@@ -33,7 +33,10 @@ gem "dotenv"
 
 group :development do
   gem "hanami-webconsole", "~> 2.3.1"
-  gem "grpc-tools"
+  # Pinned to match the version used to commit checked-in stubs.
+  # Different grpc-tools versions emit different `R<jsonName>` annotations
+  # in the descriptor blob, causing spurious churn on `bin/codegen`.
+  gem "grpc-tools", "1.76.0"
 end
 
 group :development, :test do

--- a/services/monolith/workspace/Gemfile.lock
+++ b/services/monolith/workspace/Gemfile.lock
@@ -659,7 +659,7 @@ DEPENDENCIES
   dry-types (~> 1.9, >= 1.9.1)
   faker (~> 3.8)
   grpc
-  grpc-tools
+  grpc-tools (= 1.76.0)
   gruf
   hanami (~> 2.3.2)
   hanami-assets (~> 2.3.0)


### PR DESCRIPTION
## Summary

過去の subagent dispatch で繰り返し報告された「他 slice の stub に churn が出る」「monolith は bin/codegen / frontend は pnpm proto:gen と分かれてて混乱する」を dev infra 側で潰す。

### Changes

**1. `services/monolith/workspace/Gemfile`: grpc-tools を 1.76.0 に固定**

`grpc-tools` 未固定だった → 環境ごとに微妙に違うバージョンが入って descriptor blob (R<jsonName> annotations) が変わり、proto を全く触ってない slice の stub まで churn。Gemfile.lock 既に 1.76.0 で resolve 済なので bundle check で破壊なし。

```ruby
# Pinned to match the version used to commit checked-in stubs.
# Different grpc-tools versions emit different `R<jsonName>` annotations
# in the descriptor blob, causing spurious churn on `bin/codegen`.
gem "grpc-tools", "1.76.0"
```

**2. `bin/codegen`: repo-root convenience script**

monolith/frontend それぞれの codegen entry point を 1 コマンドで実行するシェルラッパー。NODE_OPTIONS の cmux preload (subagent 環境) も自動で `env -u` 剥がす。

```bash
$ ./bin/codegen
[codegen] regenerating Ruby stubs (monolith)...
[codegen] regenerating TypeScript stubs (frontend)...
[codegen] done.
```

両 stub 出力ディレクトリで diff 0 を確認 → version pin 後の codegen は完全に deterministic。

## Verification
- `./bin/codegen` end-to-end 実行 → 0 file changes (Gemfile + bin/codegen 自身を除く)
- `bundle check`: dependencies satisfied (Gemfile.lock 維持)

## Discovery context
過去 PR の subagent dispatch で頻発した dev infra な摩擦の清算。今後 proto を触る PR では「触った slice の stub のみ」コミットされる。

## Stack
- 監査 P2 残 (#101 / #102) は design 判断要なので continuing autonomous backlog は本 PR で一旦完了