### PR TITLE
chore(frontend): fix 3 lint warnings (lint baseline 0e/1w)

### DIFF
--- a/services/frontend/workspace/src/app/apple-icon.tsx
+++ b/services/frontend/workspace/src/app/apple-icon.tsx
@@ -26,8 +26,9 @@ export default function Icon() {
         background: "transparent",
       }}
     >
-      {/* Render SVG as an image */}
+      {/* Render SVG as an image (alt empty: decorative — this IS the icon). */}
       <img
+        alt=""
         src={`data:image/svg+xml;base64,${svg.toString("base64")}`}
         style={{ width: "100%", height: "100%" }}
       />

--- a/services/frontend/workspace/src/lib/hooks/usePaginatedFetch.ts
+++ b/services/frontend/workspace/src/lib/hooks/usePaginatedFetch.ts
@@ -100,7 +100,8 @@ export function usePaginatedFetch<T, R = unknown>(
 
       return res.json();
     },
-    [apiUrl, authenticated, fetchFn]
+    // apiUrl is unused inside the body — url comes via parameter.
+    [authenticated, fetchFn]
   );
 
   const fetchInitial = useCallback(async () => {

--- a/services/frontend/workspace/src/modules/media/hooks/useMediaUpload.ts
+++ b/services/frontend/workspace/src/modules/media/hooks/useMediaUpload.ts
@@ -122,7 +122,7 @@ export function useMediaUpload(): UseMediaUploadResult {
         setUploading(false);
       }
     },
-    []
+    [registerMedia]
   );
 
   return {


### PR DESCRIPTION
## Summary

Frontend の lint warning を 3 件まとめて修正。残 1 件は `post-card.tsx` の `<img>` → `next/image` 変換で polish scope。

### Changes

**1. `src/app/apple-icon.tsx:30` — jsx-a11y/alt-text**

Open Graph icon SVG レンダリングの `<img>` に `alt=""` を追加 (decorative)。

**2. `src/lib/hooks/usePaginatedFetch.ts:103` — react-hooks/exhaustive-deps (unnecessary)**

`doFetch` callback の deps `[apiUrl, ...]` から `apiUrl` 撤去。`apiUrl` は body 内未使用 (url はパラメータ経由)。

**3. `src/modules/media/hooks/useMediaUpload.ts:125` — react-hooks/exhaustive-deps (missing)**

`uploadMedia` callback の deps `[]` に `registerMedia` 追加。body line 113 で呼んでるのに deps 抜けで stale closure 化していた潜在バグ。

### Verification
- pnpm tsc: clean
- pnpm build: success
- **pnpm lint: 0 errors / 1 warning** (1e/5w → 0e/4w (#745) → 0e/1w (本 PR))

## Stack
- baseline がさらに 0e/1w に。next/image 変換は別 PR (post-card.tsx の `<img>` を Image に置換するには src/sizes を厳密化する必要、polish scope)