### PR TITLE
chore(frontend): convert post-card images to next/image

### DIFF
--- a/services/frontend/workspace/next.config.ts
+++ b/services/frontend/workspace/next.config.ts
@@ -1,8 +1,26 @@
 import type { NextConfig } from "next";
 
+// Media (avatars / post images) is served from the monolith's storage adapter
+// as an absolute URL built from its APP_URL. The host is environment-specific,
+// so derive the allowed remotePattern from NEXT_PUBLIC_MEDIA_URL rather than
+// hardcoding it.
+const mediaUrl = new URL(
+  process.env.NEXT_PUBLIC_MEDIA_URL || "http://localhost:3000"
+);
+
 const nextConfig: NextConfig = {
   output: "standalone",
   transpilePackages: ["@frontend/rpc"],
+  images: {
+    remotePatterns: [
+      {
+        protocol: mediaUrl.protocol.replace(":", "") as "http" | "https",
+        hostname: mediaUrl.hostname,
+        port: mediaUrl.port || undefined,
+        pathname: "/uploads/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/services/frontend/workspace/src/components/ui/post-card.tsx
+++ b/services/frontend/workspace/src/components/ui/post-card.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Image from "next/image";
 import { Avatar } from "./avatar";
 import { cn } from "@/lib/utils";
 
@@ -38,12 +39,15 @@ export function PostCard({
               )}
             >
               {images.slice(0, 4).map((src, i) => (
-                <img
-                  key={i}
-                  src={src}
-                  alt=""
-                  className="aspect-video w-full object-cover"
-                />
+                <div key={i} className="relative aspect-video w-full">
+                  <Image
+                    src={src}
+                    alt=""
+                    fill
+                    sizes="(min-width: 640px) 320px, 50vw"
+                    className="object-cover"
+                  />
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- `PostCard` の生 `<img>` を `next/image` に変換し、`@next/next/no-img-element` lint warning を解消。frontend lint baseline を **0 errors / 0 warnings** に。
- 画像はレスポンシブグリッド内 (`w-full` + `aspect-video`) なので `fill` を採用し、`relative aspect-video` ラッパーで囲む。`sizes` で 1〜2 カラムレイアウトに合わせたヒントを付与。
- media は monolith の storage adapter が `APP_URL` ベースの**絶対 URL**で配信するため、`next/image` には `remotePatterns` が必要。host が環境依存なので `NEXT_PUBLIC_MEDIA_URL` (default `http://localhost:3000`) から導出し、`/uploads/**` を許可。

## Verification
- `tsc --noEmit`: clean
- `pnpm lint`: 0 errors / 0 warnings
- `pnpm build`: ✓ Compiled successfully

## Backlog ref
handoff doc Section 5 A: `post-card.tsx <img> → next/image`