### PR TITLE
feat(frontend): desktop left nav sidebar (Phase 1b-B PR1)

### DIFF
--- a/docs/superpowers/2026-06-18-session-handoff.md
+++ b/docs/superpowers/2026-06-18-session-handoff.md
@@ -10,14 +10,14 @@
 
 **Roles:** Cast (従事者、所属店舗は属性) / Guest (客)。3 ロール化はしない (店舗は属性扱い)。
 
-**Current state (2026-06-18 終了時点):**
+**Current state (2026-06-19 進行中):**
 
 - **Phase 0 token 基盤** ✅ / **Phase 1a component vocabulary** ✅ / **Phase 1b-A app shell** ✅
-- **Phase 1b-B desktop 3-col layout** ⏸ 未着手 (capture 揃ってる、design 追加不要)
+- **Phase 1b-B desktop 3-col layout** 🔄 進行中 (PR1 = 左 nav sidebar + 中央 feed、右「おすすめユーザー」pane は PR2)
 - **Phase 2 各ページ刷新** 🔄 進行中 (rx-sns parity polish per page)
 - **Phase 3 karte** ⛔ 法務 hard gate
 - **Domain slices**: identity / profile / media / post / feed / social / discovery / bookmarks / notifications / messaging / footprints 全 ✅ / trust 凍結中
-- **frontend lint baseline**: **0 error / 1 warning** (post-card.tsx 内 `<img>` → `next/image` 変換のみ残)
+- **frontend lint baseline**: **0 error / 0 warning** (#750 で post-card.tsx `<img>` → `next/image` 完了)
 - **monolith Dockerfile**: bundle frozen install 有効、Ruby 4.0.3 + grpc/grpc-tools 1.81.1 + google-protobuf 4.35.1
 - **proto codegen**: repo-root `./bin/codegen` で Ruby + TS 両方 regen、stub churn 構造的に解消済
 
@@ -28,7 +28,7 @@
 | **0** | token foundation (color / typography) | ✅ | #645 (squash bd67c616), `docs/superpowers/specs/2026-05-29-design-system-design.md` |
 | **1a** | component vocabulary (7 components: Button/Input/Tab/Toggle/Avatar/UserCard/PostCard) | ✅ | `src/components/ui/`, `/dev/ui` mock |
 | **1b-A** | mobile app shell (TopBar + BottomTab + Drawer + FAB) | ✅ | #698 spec / #699 impl |
-| **1b-B** | desktop 3-col layout (left nav + center feed + right おすすめユーザー) | ⏸ **未着手** | capture: `.superpowers/rx-sns-render/cast-{search,oshi,bookmarks,settings,ranking}.png` |
+| **1b-B** | desktop 3-col layout (left nav + center feed + right おすすめユーザー) | 🔄 **進行中** | PR1 = `SideNav` 左 nav + 中央 feed (AppShell 3-col 化、TopBar を `md:hidden`)。右 pane は PR2 (SuggestUsers data source 設計が要、未着手) |
 | **2** | per-page rebuilds (rx-sns parity polish) | 🔄 部分着地 | 監査 rev2 で大半着地、残 P2 (`#101`, `#102`) |
 | **3** | karte (cast→guest private 記録 / Cast 間共有) | ⛔ 法務 hard gate | 設計確定前に弁護士レビュー必須 |
 
@@ -73,7 +73,21 @@
 - **Post hydration (id 配列)**: `Post::Slice["use_cases.posts.list_posts_by_ids"]` (内部に Social::FilterVisiblePosts 包含)
 - **Notification preferences gating (#739 で実施)**: `Notifications::UseCases::Emit` が recipient の preferences を読んで per-type skip。`Footprints::UseCases::RecordVisit` (#742) が visitor の preferences を読んで `footprints_record_my_visits=false` で skip
 
-## 4. This Session's Deliverables (#718-#746, 計 25 PR)
+## 4. This Session's Deliverables
+
+### Session 2026-06-19 (継続、autonomous backlog 消化)
+
+handoff doc Section 5 A の backlog を A 路線で消化中。
+
+| PR | スコープ | 状態 |
+|---|---|---|
+| #750 | post-card.tsx `<img>` → `next/image` (fill + `NEXT_PUBLIC_MEDIA_URL` 由来 remotePatterns)。lint baseline **0e/0w** 達成 | auto-merge 済 |
+| #751 | Notifications preferences spec backfill (`docs/superpowers/specs/2026-06-18-notification-preferences-design.md`) | auto-merge 済 |
+| (本 PR) | Phase 1b-B PR1: `SideNav` desktop 左 nav + AppShell 3-col 化 (TopBar `md:hidden`)。右「おすすめユーザー」pane は PR2 | 進行中 |
+
+**残 backlog (Section 5 A)**: Phase 1b-B PR2 (右 pane + SuggestUsers data source)、Footprints 訪問回数 column (Non-Goals なので保留)。
+
+### Session 2026-06-18 Deliverables (#718-#746, 計 25 PR)
 
 ### Tier 3 profile content tabs (4)
 | PR | スコープ |
@@ -142,10 +156,10 @@
 
 | 項目 | スコープ | 推定 | Why |
 |---|---|---|---|
-| post-card.tsx `<img>` → `next/image` | sizing 戦略 (width/height vs fill) + `next.config.js` の `remotePatterns` 設定 | 1 PR small | 残 lint warning 1 件、これで baseline 0e/0w |
-| Phase 1b-B desktop 3-col layout | rx-sns desktop capture 同等の 3 column (左 nav text labels + 中央 feed + 右 おすすめユーザー pane) を `md:` breakpoint 以上で適用 | 2-3 PR medium | capture 揃ってる (`.superpowers/rx-sns-render/cast-{search,oshi,settings,ranking,bookmarks}.png`)、新規 design 不要 |
-| Footprints 訪問回数 column | `footprints.visits.visit_count` 追加 + upsert で increment + UI で badge 表示 | 1 PR small | F0 spec Non-Goals に書いた item の 1 つ。雛形は `notifications.notifications.actor_count` 同型 |
-| Notifications spec backfill | #738-#741 で実装した preferences feature を `docs/superpowers/specs/2026-06-18-notification-preferences-design.md` に backfill | 1 PR small | spec が無いまま実装した debt |
+| ~~post-card.tsx `<img>` → `next/image`~~ | ✅ **#750 完了** (fill + `NEXT_PUBLIC_MEDIA_URL` 由来 remotePatterns)。lint baseline 0e/0w | — | — |
+| Phase 1b-B desktop 3-col layout | 🔄 PR1 進行中 (`SideNav` 左 nav + 中央 feed)。**PR2 残**: 右「おすすめユーザー」pane。data source が無いため discovery slice に `SuggestUsers` RPC 新設が要 (backend 設計判断 → brainstorming 推奨) | 残 1-2 PR medium | capture 揃ってる (`.superpowers/rx-sns-render/cast-{search,oshi,settings,ranking,bookmarks}.png`)。左+中央は design 確定済、右 pane の data source のみ未決 |
+| Footprints 訪問回数 column | `footprints.visits.visit_count` 追加 + upsert で increment + UI で badge 表示 | 1 PR small | F0 spec Non-Goals に書いた item の 1 つ (= **保留推奨**)。雛形は `notifications.notifications.actor_count` 同型 |
+| ~~Notifications spec backfill~~ | ✅ **#751 完了** (`docs/superpowers/specs/2026-06-18-notification-preferences-design.md`) | — | — |
 
 ### B. Design / 戦略判断が要る
 

--- a/services/frontend/workspace/src/components/shell/AppShell.tsx
+++ b/services/frontend/workspace/src/components/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { TopBar } from "./TopBar";
 import { BottomTab } from "./BottomTab";
 import { ComposerFAB } from "./ComposerFAB";
 import { Drawer } from "./Drawer";
+import { SideNav } from "./SideNav";
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -22,9 +23,18 @@ export function AppShell({ children }: AppShellProps) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg">
-      <TopBar onAvatarClick={() => setDrawerOpen(true)} />
-      <div className="flex-1 pb-24 md:pb-0">{children}</div>
+    <div className="min-h-screen bg-bg">
+      <div className="md:hidden">
+        <TopBar onAvatarClick={() => setDrawerOpen(true)} />
+      </div>
+      {/* Desktop: persistent left nav + center column. The space to the right of
+          the center column is reserved for the おすすめユーザー pane (Phase 1b-B PR2). */}
+      <div className="mx-auto flex w-full max-w-screen-xl">
+        <SideNav />
+        <main className="min-w-0 flex-1 pb-24 md:max-w-2xl md:border-x md:border-border md:pb-0">
+          {children}
+        </main>
+      </div>
       <BottomTab />
       <ComposerFAB />
       <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />

--- a/services/frontend/workspace/src/components/shell/SideNav.tsx
+++ b/services/frontend/workspace/src/components/shell/SideNav.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Avatar } from "@/components/ui/avatar";
+import { PostComposerModal } from "@/modules/post/components/PostComposerModal";
+import { useProfile } from "@/modules/profile/hooks";
+import { useUnreadCount, useNotificationPreferences } from "@/modules/notifications/hooks";
+import { useTotalUnread } from "@/modules/messaging";
+import { useFootprintsUnreadCount } from "@/modules/footprints";
+
+type BadgeKey = "unread" | "messaging_unread" | "footprints_unread";
+
+interface NavItem {
+  path: string;
+  label: string;
+  icon: string;
+  badgeKey?: BadgeKey;
+}
+
+// Desktop nav order mirrors the rx-sns 3-col reference (ホーム first, プロフィール
+// near the bottom). The mobile Drawer keeps its own order, so the two lists are
+// intentionally separate.
+const NAV_ITEMS: NavItem[] = [
+  { path: "/", label: "ホーム", icon: "🏠" },
+  { path: "/search", label: "検索", icon: "🔍" },
+  { path: "/notifications", label: "通知", icon: "🔔", badgeKey: "unread" },
+  { path: "/footprints", label: "足跡", icon: "👣", badgeKey: "footprints_unread" },
+  { path: "/messages", label: "メッセージ", icon: "💬", badgeKey: "messaging_unread" },
+  { path: "/bookmarks", label: "ブックマーク", icon: "🔖" },
+  { path: "/oshi", label: "推し！", icon: "⭐" },
+  { path: "/ranking", label: "ランキング", icon: "🏆" },
+  { path: "__profile__", label: "プロフィール", icon: "👤" },
+  { path: "/settings", label: "設定", icon: "⚙" },
+];
+
+export function SideNav() {
+  const pathname = usePathname();
+  const { profile } = useProfile();
+  const { count: unread } = useUnreadCount();
+  const { count: msgUnread } = useTotalUnread();
+  const { count: footprintsUnread } = useFootprintsUnreadCount();
+  const { preferences } = useNotificationPreferences();
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  const footprintsBadgeEnabled = preferences?.footprintUnreadBadge !== false;
+  const profileHref = profile?.username
+    ? `/u/${encodeURIComponent(profile.username)}`
+    : "/profile";
+
+  return (
+    <aside className="sticky top-0 hidden h-screen w-60 shrink-0 flex-col px-3 py-4 md:flex">
+      <nav className="flex-1 overflow-y-auto">
+        {NAV_ITEMS.map((item) => {
+          const href = item.path === "__profile__" ? profileHref : item.path;
+          const active = item.path === "__profile__" ? pathname === profileHref : pathname === item.path;
+          const badgeCount =
+            item.badgeKey === "unread" ? unread :
+            item.badgeKey === "messaging_unread" ? msgUnread :
+            item.badgeKey === "footprints_unread" ? (footprintsBadgeEnabled ? footprintsUnread : 0) :
+            0;
+          return (
+            <Link
+              key={item.path}
+              href={href}
+              className={`relative flex items-center gap-3 rounded-full px-4 py-3 text-base hover:bg-bg-secondary ${
+                active ? "font-bold text-text-primary" : "text-text-secondary"
+              }`}
+              aria-current={active ? "page" : undefined}
+            >
+              <span className="text-xl" aria-hidden="true">{item.icon}</span>
+              <span className="flex-1">{item.label}</span>
+              {badgeCount > 0 && (
+                <span className="min-w-[1.25rem] rounded-full bg-accent px-1 text-center text-xs font-bold text-white">
+                  {badgeCount > 99 ? "99+" : badgeCount}
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <button
+        type="button"
+        onClick={() => setComposerOpen(true)}
+        className="mt-3 rounded-full bg-gradient-brand py-3 text-center font-bold text-white shadow-brand-glow active:scale-95"
+      >
+        投稿する
+      </button>
+
+      <Link
+        href={profileHref}
+        className="mt-3 flex items-center gap-3 rounded-full px-2 py-2 hover:bg-bg-secondary"
+      >
+        <Avatar
+          src={profile?.avatarUrl || undefined}
+          fallback={(profile?.displayName || "?").slice(0, 1)}
+          size="md"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-bold text-text-primary">{profile?.displayName || "—"}</p>
+          <p className="truncate text-xs text-text-secondary">@{profile?.username || "—"}</p>
+        </div>
+      </Link>
+
+      <PostComposerModal open={composerOpen} onClose={() => setComposerOpen(false)} />
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 1b-B (desktop 3-col layout) の **PR1**。rx-sns desktop capture に倣い、`md:` breakpoint 以上で persistent な左 nav sidebar + 中央 feed カラムを導入。

- **`SideNav`** (新規): nav items (icon + label + badge)、`投稿する` gradient ボタン (PostComposerModal を開く)、下部 user chip。`md:` 未満では非表示。
- **`AppShell`**: content を `max-w-screen-xl` の flex row でラップ。中央カラムは `md:max-w-2xl` + 左右 border。右側の余白は **PR2 の「おすすめユーザー」pane 用に予約**。
- **`TopBar`**: desktop では `md:hidden`（avatar/drawer + bell の機能は sidebar が担う）。BottomTab / ComposerFAB は既に `md:hidden`。

右「おすすめユーザー」pane は、user 推薦の data source が現状存在しない（discovery は searchPosts / rankPosts / searchUsers のみ）ため **PR2** に分割。`SuggestUsers` RPC 新設の設計判断が要る。

## Handoff doc 更新
進捗を見失わないよう `2026-06-18-session-handoff.md` を更新:
- #750 (lint baseline 0e/0w) / #751 (notification preferences spec) を完了に
- Phase 1b-B を 🔄 進行中（PR1/PR2 分割）に
- Section 4 に 2026-06-19 継続セッションのブロック追加

## Verification
- `tsc --noEmit`: clean
- `pnpm lint`: 0 errors / 0 warnings
- `pnpm build`: ✓ Compiled successfully

## Backlog ref
handoff doc Section 5 A: `Phase 1b-B desktop 3-col layout`