### PR TITLE
chore(frontend): pin @bufbuild/protoc-gen-es to exact 2.12.0

### DIFF
--- a/services/frontend/workspace/package.json
+++ b/services/frontend/workspace/package.json
@@ -38,7 +38,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
-    "@bufbuild/protoc-gen-es": "^2.12.0",
+    "@bufbuild/protoc-gen-es": "2.12.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",

--- a/services/frontend/workspace/pnpm-lock.yaml
+++ b/services/frontend/workspace/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         version: 5.0.14(@types/react@19.2.17)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
       '@bufbuild/protoc-gen-es':
-        specifier: ^2.12.0
+        specifier: 2.12.0
         version: 2.12.0(@bufbuild/protobuf@2.12.0)
       '@tailwindcss/postcss':
         specifier: ^4.2.4


### PR DESCRIPTION
## Summary
`@bufbuild/protoc-gen-es` の caret (`^2.12.0`) を外し **exact `2.12.0`** に pin。codegen plugin の minor bump で生成 TS stub が無言で churn するのを防ぐ（`@bufbuild/buf` 1.69.0 / grpc-tools と同じ exact-pin 方針に揃える）。

- 解決バージョンは不変（2.12.0）。
- `pnpm proto:gen` の出力は byte-identical（stub churn なし）を確認。
- `@bufbuild/protobuf` は runtime import で生成内容に影響しないため scope 外（caret のまま）。

## Backlog ref
handoff doc Section 5 C: `protoc-gen-es version pin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version pinning for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->