### PR TITLE
feat(frontend): dystopia.city brand mark in shell

### DIFF
--- a/docs/superpowers/2026-06-18-session-handoff.md
+++ b/docs/superpowers/2026-06-18-session-handoff.md
@@ -168,7 +168,7 @@ handoff doc Section 5 A の backlog を A 路線で消化中。
 | 項目 | 必要なもの | Memo |
 |---|---|---|
 | **#101 Settings 外観 tab** (theme switcher) | light mode 色トークン設計 + ThemeProvider + localStorage 永続化 | rx-sns capture: `.superpowers/rx-sns-render/p04-settings-外観.png` (3 radio: ライト/ダーク/システム)。token は `src/app/globals.css` の `--color-*` を CSS variable で出し分け |
-| **#102 Top header brand mark** | brand logo asset (現状 `dystopia.city` 文字撤去後の center が空) | rx-sns の R-mark 相当。design 判断要 |
+| ~~**#102 Top header brand mark**~~ | ✅ **完了** (本 PR) | サービス名 = **dystopia.city** で確定。`BrandMark` (brand-gradient wordmark) を SideNav 上部 + mobile TopBar center に配置。本ロゴ確定時は `BrandMark` 差し替えで対応 |
 | Messaging media attach | spec (proto + storage 設計 + UI) | M-spec deferred item |
 | Messaging reactions / quote-reply / edit-delete | spec | M-spec deferred |
 | Push provider 接続 (FCM/APNS) | infra 判断 (Firebase か, native のみか, web push か) | preferences `push_enabled` は currently UI のみ、実 push なし |

--- a/services/frontend/workspace/src/components/shell/BrandMark.tsx
+++ b/services/frontend/workspace/src/components/shell/BrandMark.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+export interface BrandMarkProps {
+  className?: string;
+}
+
+// dystopia.city wordmark, rendered as brand-gradient text. Links to home.
+export function BrandMark({ className }: BrandMarkProps) {
+  return (
+    <Link
+      href="/"
+      aria-label="dystopia.city ホーム"
+      className={cn(
+        "bg-gradient-brand bg-clip-text font-bold tracking-tight text-transparent",
+        className
+      )}
+    >
+      dystopia.city
+    </Link>
+  );
+}

--- a/services/frontend/workspace/src/components/shell/SideNav.tsx
+++ b/services/frontend/workspace/src/components/shell/SideNav.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Avatar } from "@/components/ui/avatar";
+import { BrandMark } from "./BrandMark";
 import { PostComposerModal } from "@/modules/post/components/PostComposerModal";
 import { useProfile } from "@/modules/profile/hooks";
 import { useUnreadCount, useNotificationPreferences } from "@/modules/notifications/hooks";
@@ -51,6 +52,7 @@ export function SideNav() {
 
   return (
     <aside className="sticky top-0 hidden h-screen w-60 shrink-0 flex-col px-3 py-4 md:flex">
+      <BrandMark className="px-4 pb-4 text-xl" />
       <nav className="flex-1 overflow-y-auto">
         {NAV_ITEMS.map((item) => {
           const href = item.path === "__profile__" ? profileHref : item.path;

--- a/services/frontend/workspace/src/components/shell/TopBar.tsx
+++ b/services/frontend/workspace/src/components/shell/TopBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { Avatar } from "@/components/ui/avatar";
+import { BrandMark } from "./BrandMark";
 import { useProfile } from "@/modules/profile/hooks";
 import { useUnreadCount } from "@/modules/notifications/hooks";
 
@@ -25,7 +26,7 @@ export function TopBar({ onAvatarClick }: TopBarProps) {
       >
         <Avatar src={avatarUrl} fallback={fallback} size="sm" />
       </button>
-      <div aria-hidden="true" />
+      <BrandMark className="text-base" />
       <Link
         href="/notifications"
         className="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-xl hover:bg-bg-secondary"


### PR DESCRIPTION
## Summary
Top header / sidebar の brand mark を実装。サービス名は **dystopia.city** で確定（既に `layout.tsx` の title）。

- 新規 `BrandMark`: `dystopia.city` を brand gradient text（`bg-gradient-brand bg-clip-text text-transparent`）で描画、home へリンク。
- **desktop**: `SideNav` 上部（nav の上）に配置。
- **mobile**: `TopBar` center の空 placeholder（`<div aria-hidden>`）を置き換え。
- 本デザインロゴが確定したら `BrandMark` 内を差し替えるだけで対応可能。

## Verification
- `tsc --noEmit` clean / `pnpm lint` 0e/0w / `pnpm build` ✓ Compiled

## Backlog ref
handoff doc Section 5 B: `#102 Top header brand mark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)