### PR TITLE
feat(frontend): theme switcher — light mode + Settings 外観 tab (#101)

### DIFF
--- a/docs/superpowers/2026-06-18-session-handoff.md
+++ b/docs/superpowers/2026-06-18-session-handoff.md
@@ -167,7 +167,7 @@ handoff doc Section 5 A の backlog を A 路線で消化中。
 
 | 項目 | 必要なもの | Memo |
 |---|---|---|
-| **#101 Settings 外観 tab** (theme switcher) | light mode 色トークン設計 + ThemeProvider + localStorage 永続化 | rx-sns capture: `.superpowers/rx-sns-render/p04-settings-外観.png` (3 radio: ライト/ダーク/システム)。token は `src/app/globals.css` の `--color-*` を CSS variable で出し分け |
+| ~~**#101 Settings 外観 tab** (theme switcher)~~ | ✅ **完了** (本 PR) | 自前テーマ基盤（no-flash inline script + `ThemeProvider`/`useTheme`、依存なし。next-themes は ~13ヶ月 dormant、@wrksz/themes は若く単独メンテナで不採用）。`[data-theme="light"]` で semantic alias 上書き、外観 tab (ライト/ダーク/システム)。spec `2026-06-19-theme-switcher-design.md` / plan `2026-06-19-theme-switcher.md` |
 | ~~**#102 Top header brand mark**~~ | ✅ **完了** (本 PR) | サービス名 = **dystopia.city** で確定。`BrandMark` (brand-gradient wordmark) を SideNav 上部 + mobile TopBar center に配置。本ロゴ確定時は `BrandMark` 差し替えで対応 |
 | Messaging media attach | spec (proto + storage 設計 + UI) | M-spec deferred item |
 | Messaging reactions / quote-reply / edit-delete | spec | M-spec deferred |

--- a/docs/superpowers/plans/2026-06-19-theme-switcher.md
+++ b/docs/superpowers/plans/2026-06-19-theme-switcher.md
@@ -1,0 +1,376 @@
+# Theme Switcher (light mode + 外観 tab) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a light theme and a Settings 外観 tab (light/dark/system) using a self-rolled no-flash script + React context, with the light palette layered on the existing token system.
+
+**Architecture:** A `[data-theme="light"]` block in globals.css overrides the dark semantic color aliases; a no-flash inline script in the root layout sets `<html data-theme>` before paint from localStorage; a `ThemeProvider`/`useTheme` context manages the choice (light/dark/system), persists it, and follows the OS in system mode; an `AppearanceSettings` component drives it from a new Settings tab.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, Tailwind v4 (CSS custom properties / `@theme inline`). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-theme-switcher-design.md`
+
+**Verification conventions:**
+- No frontend unit-test harness exists; the gate is `tsc --noEmit` + `pnpm lint` (0e/0w) + `pnpm build`, plus the manual checks listed per task.
+- Run frontend commands from `services/frontend/workspace` with `env -u NODE_OPTIONS`.
+- Bare `find`/`grep` are shadowed in this environment — use `/usr/bin/find` / `/usr/bin/grep`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `services/frontend/workspace/src/app/globals.css` | add `[data-theme="light"]` semantic-alias overrides | Modify |
+| `services/frontend/workspace/src/components/providers/ThemeProvider.tsx` | theme choice context: persist, apply to `<html data-theme>`, follow OS in system mode | Create |
+| `services/frontend/workspace/src/app/layout.tsx` | no-flash inline script + wrap app in `ThemeProvider` | Modify |
+| `services/frontend/workspace/src/modules/profile/components/AppearanceSettings.tsx` | 外観 tab UI (light/dark/system radio group) | Create |
+| `services/frontend/workspace/src/app/settings/page.tsx` | add "外観" tab | Modify |
+
+---
+
+## Task 1: Theme infrastructure (CSS + no-flash script + provider)
+
+**Files:**
+- Modify: `services/frontend/workspace/src/app/globals.css`
+- Create: `services/frontend/workspace/src/components/providers/ThemeProvider.tsx`
+- Modify: `services/frontend/workspace/src/app/layout.tsx`
+
+- [ ] **Step 1: Add the light palette to globals.css**
+
+In `services/frontend/workspace/src/app/globals.css`, immediately AFTER the closing `}` of the existing `:root { ... }` block (the one that ends right before `/* root font-size 15px ... */`), insert this block. The existing `:root` already holds the dark values and stays unchanged; this override wins for light because it has equal specificity and comes later in source order.
+
+```css
+/* Light theme: override only the semantic aliases. Neutral/brand scales,
+   gradients, and radius stay shared in :root (dark default). */
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --color-surface: var(--color-neutral-100);
+  --color-bg-secondary: var(--color-neutral-200);
+  --color-divider: var(--color-neutral-200);
+  --color-border: var(--color-neutral-300);
+  --color-text-primary: var(--color-neutral-900);
+  --color-text-secondary: var(--color-neutral-500);
+  --color-text-muted: var(--color-neutral-400);
+  --color-input-bg: var(--color-neutral-100);
+  --color-accent: var(--color-brand-primary);
+}
+```
+
+- [ ] **Step 2: Create the ThemeProvider**
+
+Create `services/frontend/workspace/src/components/providers/ThemeProvider.tsx`:
+
+```tsx
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+export type ThemeChoice = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme";
+
+interface ThemeContextValue {
+  theme: ThemeChoice;
+  setTheme: (t: ThemeChoice) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function applyTheme(choice: ThemeChoice) {
+  const dark =
+    choice === "dark" ||
+    (choice === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeChoice>("system");
+  const [loaded, setLoaded] = useState(false);
+
+  // Read the stored choice on the client. Until this runs, leave the value the
+  // no-flash inline script already set (don't clobber it on the server-default).
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    setThemeState(
+      stored === "light" || stored === "dark" || stored === "system" ? stored : "system"
+    );
+    setLoaded(true);
+  }, []);
+
+  // Apply on change, and follow the OS while in system mode.
+  useEffect(() => {
+    if (!loaded) return;
+    applyTheme(theme);
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme("system");
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [theme, loaded]);
+
+  const setTheme = useCallback((t: ThemeChoice) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    setThemeState(t);
+  }, []);
+
+  return <ThemeContext.Provider value={{ theme, setTheme }}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}
+```
+
+- [ ] **Step 3: Wire the no-flash script + provider into layout**
+
+In `services/frontend/workspace/src/app/layout.tsx`:
+
+Add the import alongside the other provider imports (after `import { AppShell } from "@/components/shell";`):
+
+```tsx
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+```
+
+Replace the current body block:
+
+```tsx
+      <body className="antialiased bg-bg">
+        <AuthProvider>
+          <SWRProvider>
+            <AppShell>{children}</AppShell>
+          </SWRProvider>
+        </AuthProvider>
+      </body>
+```
+
+with (the inline script must be the first child of `<body>` so it runs before content paints; `<html suppressHydrationWarning>` is already present):
+
+```tsx
+      <body className="antialiased bg-bg">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("theme")||"system";var d=t==="dark"||(t==="system"&&window.matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.dataset.theme=d?"dark":"light";}catch(e){}})();`,
+          }}
+        />
+        <ThemeProvider>
+          <AuthProvider>
+            <SWRProvider>
+              <AppShell>{children}</AppShell>
+            </SWRProvider>
+          </AuthProvider>
+        </ThemeProvider>
+      </body>
+```
+
+- [ ] **Step 4: Verify the gate**
+
+Run:
+```bash
+cd services/frontend/workspace
+env -u NODE_OPTIONS ./node_modules/.bin/tsc --noEmit
+env -u NODE_OPTIONS pnpm lint
+env -u NODE_OPTIONS pnpm build
+```
+Expected: tsc clean; lint `0 errors / 0 warnings`; build `✓ Compiled successfully`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/frontend/workspace/src/app/globals.css \
+        services/frontend/workspace/src/components/providers/ThemeProvider.tsx \
+        services/frontend/workspace/src/app/layout.tsx
+git commit -s -m "feat(frontend): theme infrastructure (light palette + no-flash script + ThemeProvider)"
+```
+
+---
+
+## Task 2: AppearanceSettings + Settings 外観 tab
+
+**Files:**
+- Create: `services/frontend/workspace/src/modules/profile/components/AppearanceSettings.tsx`
+- Modify: `services/frontend/workspace/src/app/settings/page.tsx`
+
+- [ ] **Step 1: Create AppearanceSettings**
+
+Create `services/frontend/workspace/src/modules/profile/components/AppearanceSettings.tsx`. The `mounted` guard prevents a hydration mismatch: the provider's `theme` starts at `"system"` on the server but may differ once localStorage is read, so no option renders as selected until mounted.
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme, type ThemeChoice } from "@/components/providers/ThemeProvider";
+
+const OPTIONS: { value: ThemeChoice; label: string }[] = [
+  { value: "light", label: "ライト" },
+  { value: "dark", label: "ダーク" },
+  { value: "system", label: "システム" },
+];
+
+export function AppearanceSettings() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <h2 className="text-sm font-semibold text-text-secondary">テーマ</h2>
+      <div role="radiogroup" aria-label="テーマ" className="flex flex-col gap-2">
+        {OPTIONS.map((opt) => {
+          const selected = mounted && theme === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => setTheme(opt.value)}
+              className={`flex items-center justify-between rounded-md border px-4 py-3 text-left text-sm ${
+                selected
+                  ? "border-accent text-text-primary"
+                  : "border-border text-text-secondary hover:bg-bg-secondary"
+              }`}
+            >
+              <span>{opt.label}</span>
+              <span
+                aria-hidden="true"
+                className={`h-4 w-4 rounded-full border ${
+                  selected ? "border-accent bg-accent" : "border-border"
+                }`}
+              />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add the 外観 tab to the settings page**
+
+In `services/frontend/workspace/src/app/settings/page.tsx`:
+
+Add the import after `import { NotificationSettings } from "@/modules/notifications/components/NotificationSettings";`:
+
+```tsx
+import { AppearanceSettings } from "@/modules/profile/components/AppearanceSettings";
+```
+
+Change the `items` array to include 外観 (after privacy, before account — keeps account last):
+
+```tsx
+  const items = [
+    { id: "notifications", label: "通知設定" },
+    ...(role === "cast" ? [{ id: "area", label: "エリア" }] : []),
+    { id: "privacy", label: "プライバシー" },
+    { id: "appearance", label: "外観" },
+    { id: "account", label: "アカウント" },
+  ];
+```
+
+Add the render branch in the tab content block (after the privacy branch, before account):
+
+```tsx
+        {tab === "privacy" && <PrivacySettings profile={profile} save={saveProfile} />}
+        {tab === "appearance" && <AppearanceSettings />}
+        {tab === "account" && <AccountSettings profile={profile} save={saveProfile} />}
+```
+
+- [ ] **Step 3: Verify the gate**
+
+Run:
+```bash
+cd services/frontend/workspace
+env -u NODE_OPTIONS ./node_modules/.bin/tsc --noEmit
+env -u NODE_OPTIONS pnpm lint
+env -u NODE_OPTIONS pnpm build
+```
+Expected: tsc clean; lint `0 errors / 0 warnings`; build `✓ Compiled successfully`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/frontend/workspace/src/modules/profile/components/AppearanceSettings.tsx \
+        services/frontend/workspace/src/app/settings/page.tsx
+git commit -s -m "feat(frontend): Settings 外観 tab (light/dark/system selector)"
+```
+
+---
+
+## Task 3: Raw color audit for light mode
+
+**Files:**
+- Modify: any `.tsx` under `services/frontend/workspace/src` that uses dark-assuming fixed colors (determined in Step 1).
+
+- [ ] **Step 1: List raw color usages**
+
+Run:
+```bash
+cd services/frontend/workspace
+/usr/bin/grep -rn "neutral-\|text-white\|bg-white\|bg-black\|text-black\|#fff\|#000" src --include=*.tsx
+```
+This yields ~17 hits. For each, classify:
+- **Keep** (theme-agnostic): `text-white` on a `bg-gradient-brand` / accent element (white reads on the brand gradient in both themes); usages inside `src/app/dev/ui/` (the dev-only mock page).
+- **Fix** (dark-assuming): a fixed `text-white` / `bg-black` / `text-black` / raw `neutral-*` / hex that sits on a theme surface and would become invisible or wrong in light mode.
+
+- [ ] **Step 2: Replace dark-assuming usages with semantic tokens**
+
+For each "Fix" hit, replace the fixed color with the semantic token that matches its intent:
+- body/heading text → `text-text-primary`
+- secondary/meta text → `text-text-secondary` / `text-text-muted`
+- surface backgrounds → `bg-surface` / `bg-bg` / `bg-bg-secondary`
+- borders/dividers → `border-border` / `border-divider`
+
+Do NOT change `text-white` that sits on `bg-gradient-brand`/`bg-accent` (intentional in both themes). If a hit is genuinely theme-agnostic, leave it and move on.
+
+- [ ] **Step 3: Verify the gate**
+
+Run:
+```bash
+cd services/frontend/workspace
+env -u NODE_OPTIONS ./node_modules/.bin/tsc --noEmit
+env -u NODE_OPTIONS pnpm lint
+env -u NODE_OPTIONS pnpm build
+```
+Expected: tsc clean; lint `0 errors / 0 warnings`; build `✓ Compiled successfully`.
+
+- [ ] **Step 4: Commit** (skip if Step 1 found nothing to fix)
+
+```bash
+git add -A
+git commit -s -m "fix(frontend): use semantic color tokens for light-mode correctness"
+```
+
+---
+
+## Task 4: Update session handoff doc
+
+**Files:**
+- Modify: `docs/superpowers/2026-06-18-session-handoff.md`
+
+- [ ] **Step 1: Mark #101 done**
+
+In `docs/superpowers/2026-06-18-session-handoff.md`, Section 5 B, change the `#101 Settings 外観 tab` row to completed (`~~...~~ | ✅ 完了 (本 PR) | ...`), noting: self-rolled theme infra (no-flash script + ThemeProvider, no dependency — next-themes was ~13mo dormant; @wrksz/themes evaluated but too young/single-maintainer), `[data-theme="light"]` palette, 外観 tab (light/dark/system). Match the surrounding `✅`/strikethrough table style.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/2026-06-18-session-handoff.md
+git commit -s -m "docs: mark #101 theme switcher complete in session handoff"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `cd services/frontend/workspace && env -u NODE_OPTIONS ./node_modules/.bin/tsc --noEmit && env -u NODE_OPTIONS pnpm lint && env -u NODE_OPTIONS pnpm build` (tsc clean, 0e/0w, build ok)
+- [ ] Manual (local e2e, if run): 外観 tab switches light/dark/system → `<html data-theme>` updates immediately; reload persists the choice (localStorage `theme`); "システム" follows OS dark/light toggle; no FOUC on first load; feed / profile / settings / footprints / messages are readable in light mode; dark mode looks unchanged from before.
+- [ ] Push branch, open Draft PR (conventional title), `gh pr ready`, `gh pr merge --squash --delete-branch --auto`.
+
+**Success criteria (from spec):**
+- 3 choices work, persist, and follow the OS
+- existing components are legible in light mode (no contrast breakage)
+- dark mode is visually unchanged

--- a/docs/superpowers/specs/2026-06-19-theme-switcher-design.md
+++ b/docs/superpowers/specs/2026-06-19-theme-switcher-design.md
@@ -1,0 +1,190 @@
+# Theme Switcher Design — light mode + Settings 外観 tab (#101)
+
+Date: 2026-06-19
+Status: Design spec (implementation-ready)
+Scope: ダークのみだった frontend に light テーマを追加し、Settings に「外観」tab（ライト / ダーク / システムの 3 択）を設ける。テーマは自前の no-flash script + React context で `<html data-theme>` を切替え、CSS の semantic alias を `[data-theme="light"]` で上書きする。
+
+Related:
+- `docs/superpowers/specs/2026-05-29-design-system-design.md`（token foundation, Phase 0）
+- rx-sns capture: `.superpowers/rx-sns-render/p04-settings-外観.png`（3 radio: ライト / ダーク / システム）
+- handoff doc Section 5 B `#101 Settings 外観 tab`
+
+## Goal
+
+ユーザーが外観（テーマ）をライト / ダーク / システムから選べるようにする。選択は永続化し、再読み込み・OS 設定変更に追従する。既存コンポーネントは無変更で両テーマに対応する。
+
+## Grounding
+
+- `src/app/globals.css` は `:root` に dark の semantic alias（`--color-bg` 等）を定義し、`@theme inline` でそれらを Tailwind utility（`bg-bg` / `text-text-primary` 等）へ再export している。utility は `var(--color-*)` を参照するため、`data-theme` 切替で実行時に全 utility が追従する。
+- `src/app/layout.tsx` の `<html>` は既に `suppressHydrationWarning` 付き（inline script が html 属性を書き換える前提を満たす）。provider は `@/components/providers/`（`SWRProvider` 等）に集約されている。
+- Settings (`src/app/settings/page.tsx`) は `Tabs` ベース。tab を 1 つ足すだけで拡張できる。
+- raw color（`neutral-*` / `text-white` / `bg-white` / `bg-black`）の .tsx 使用は 17 箇所のみ。大半は brand-gradient ボタン上の `text-white` でテーマ非依存。
+- Radio コンポーネントは未存在。
+
+## Decisions
+
+| 項目 | 決定 | Why |
+|---|---|---|
+| テーマ適用 | **自前実装**（inline no-flash script + React context）。依存追加なし | `next-themes` は最終リリース 2025-03 / 最終コミット 2025-05 で ~13ヶ月 dormant のため不採用。theme 切替は小規模で自前可能。CLAUDE.md「頼まれてない依存を追加しない」とも整合 |
+| デフォルト | `system`（OS 追従） | rx-sns も「システム」を含む。標準的 |
+| token 機構 | semantic alias のみ `[data-theme="light"]` で上書き。neutral/brand scale・gradient は共通 | コンポーネント無変更で両テーマ対応。差分最小 |
+| 外観 tab の対象 | 全ユーザー（role 非依存） | テーマは Cast/Guest 共通設定 |
+| status 色 (error/warning/info) | 両テーマ共通のまま（light 最適化しない） | §10 未確定の interim 値。本 spec の scope 外 |
+
+## Token architecture
+
+`globals.css` の `:root` ブロックの **semantic alias 部分**を dark/light で出し分ける。neutral scale・brand・gradient・radius は共通のまま。
+
+```css
+:root,
+[data-theme="dark"] {
+  --color-bg: var(--color-neutral-950);
+  --color-bg-secondary: var(--color-neutral-800);
+  --color-surface: var(--color-neutral-900);
+  --color-divider: var(--color-neutral-800);
+  --color-border: var(--color-neutral-700);
+  --color-text-primary: var(--color-neutral-50);
+  --color-text-secondary: var(--color-neutral-400);
+  --color-text-muted: var(--color-neutral-500);
+  --color-input-bg: #303030;
+  --color-accent: var(--color-brand-primary);
+}
+
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --color-surface: var(--color-neutral-100);
+  --color-bg-secondary: var(--color-neutral-200);
+  --color-divider: var(--color-neutral-200);
+  --color-border: var(--color-neutral-300);
+  --color-text-primary: var(--color-neutral-900);
+  --color-text-secondary: var(--color-neutral-500);
+  --color-text-muted: var(--color-neutral-400);
+  --color-input-bg: var(--color-neutral-100);
+  --color-accent: var(--color-brand-primary);
+}
+```
+
+- neutral scale (`--color-neutral-50..950`)・brand・gradient・glow・radius の定義は現状どおり `:root` に残す（両テーマ共通）。
+- `@theme inline` ブロックは変更不要（`var(--color-*)` 参照のまま）。
+- `body { background: var(--color-bg); color: var(--color-text-primary) }` も変更不要。
+
+### Light palette（semantic alias 一覧）
+
+| token | dark | light |
+|---|---|---|
+| `--color-bg` | `#14161a` (neutral-950) | `#ffffff` |
+| `--color-surface` | `#0f172a` (neutral-900) | `#f1f5f9` (neutral-100) |
+| `--color-bg-secondary` | `#1e293b` (neutral-800) | `#e2e8f0` (neutral-200) |
+| `--color-divider` | neutral-800 | neutral-200 |
+| `--color-border` | `#334155` (neutral-700) | `#cbd5e1` (neutral-300) |
+| `--color-text-primary` | `#f8fafc` (neutral-50) | `#0f172a` (neutral-900) |
+| `--color-text-secondary` | `#94a3b8` (neutral-400) | `#64748b` (neutral-500) |
+| `--color-text-muted` | neutral-500 | neutral-400 |
+| `--color-input-bg` | `#303030` | neutral-100 |
+| `--color-accent` | brand-primary | brand-primary（共通） |
+
+## テーマ適用（自前実装）
+
+依存追加なし。3 ピースで構成する。
+
+### (a) No-flash inline script（FOUC 回避）
+
+`layout.tsx` の `<body>` 先頭に、hydration 前に同期実行される inline script を置き、localStorage の選択を解決して `<html data-theme>` を paint 前に設定する。
+
+```tsx
+<body className="antialiased bg-bg">
+  <script
+    dangerouslySetInnerHTML={{
+      __html: `(function(){try{var t=localStorage.getItem("theme")||"system";var d=t==="dark"||(t==="system"&&window.matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.dataset.theme=d?"dark":"light";}catch(e){}})();`,
+    }}
+  />
+  <ThemeProvider>
+    <AuthProvider>
+      <SWRProvider>
+        <AppShell>{children}</AppShell>
+      </SWRProvider>
+    </AuthProvider>
+  </ThemeProvider>
+</body>
+```
+
+body 先頭で同期実行されるため、後続 DOM の paint 前に `data-theme` が確定し FOUC が出ない。`<html suppressHydrationWarning>` は既存（script が html 属性を変えるため必要、すでに付与済）。
+
+### (b) ThemeProvider + useTheme（`src/components/providers/ThemeProvider.tsx`, client）
+
+React context で `theme`（ユーザー選択: `"light" | "dark" | "system"`）と `setTheme` を提供する。
+
+- 初期 state は `"system"`（SSR と一致）。`useEffect` で localStorage の値に同期する。
+- `setTheme(t)`: state 更新 + `localStorage.setItem("theme", t)` + 解決済みテーマを `document.documentElement.dataset.theme` に反映。
+- `theme === "system"` のとき `window.matchMedia("(prefers-color-scheme: dark)")` の `change` を購読し、OS 切替に追従して `data-theme` を更新する。`theme` が light/dark のときはリスナーを外す。
+- `useTheme()` フックで `{ theme, setTheme }` を公開。
+
+型: `type ThemeChoice = "light" | "dark" | "system";`
+
+`layout.tsx` で既存 provider 群を `<ThemeProvider>` でラップ（最外）。
+
+### (c) localStorage キー
+
+`"theme"`（値は `ThemeChoice`）。inline script と ThemeProvider で同一キーを使う。
+
+## Settings 外観 tab
+
+`src/app/settings/page.tsx` の `items` に追加（role 非依存）:
+
+```tsx
+const items = [
+  { id: "notifications", label: "通知設定" },
+  ...(role === "cast" ? [{ id: "area", label: "エリア" }] : []),
+  { id: "appearance", label: "外観" },
+  { id: "privacy", label: "プライバシー" },
+  { id: "account", label: "アカウント" },
+];
+```
+
+`{tab === "appearance" && <AppearanceSettings />}` を描画。
+
+新規 `src/modules/profile/components/AppearanceSettings.tsx`（client）:
+- 自前 `useTheme()`（(b)）の `theme` / `setTheme` を使う。
+- 3 つの選択肢を radio 風 UI で表示: `{ value: "light", label: "ライト" }`, `{ value: "dark", label: "ダーク" }`, `{ value: "system", label: "システム" }`。
+- SSR/hydration 不一致を避けるため、`mounted` フラグ（`useEffect` で true）が立つまで選択状態をプレースホルダ表示にする（初期 state が "system" 固定で実選択と異なりうるため）。
+- 各行は `NotificationSettings` の `ToggleRow` 風の見た目（label + 右側に選択コントロール）に合わせ、Settings 内の一貫性を保つ。
+
+## Raw color audit
+
+`neutral-*` / `text-white` / `bg-white` / `bg-black` の 17 箇所を確認し、**dark を前提に固定色を使っている箇所のみ** semantic token（`text-text-primary` 等）へ置換する。brand-gradient 上の `text-white`（ボタン等）はテーマ非依存なので据え置く。置換が必要な代表例は light で視認できなくなる固定 `text-white`/`bg-black` 等。
+
+## Decomposition（実装段）
+
+| 段 | スコープ |
+|---|---|
+| T1 | globals.css の `[data-theme]` 出し分け（dark 既定維持）+ no-flash inline script + 自前 `ThemeProvider`/`useTheme` + layout 統合 |
+| T2 | `AppearanceSettings` + Settings 外観 tab |
+| T3 | raw color audit & 置換（light で破綻する箇所のみ） |
+
+## Deferred / out of scope
+
+- status 色（error/warning/info）の light 最適化（§10 未確定）
+- brand 色の light 調整（共通で十分）
+- per-route / 印刷用テーマ
+- テーマ別の画像・ロゴ出し分け
+
+## Verification
+
+```bash
+cd services/frontend/workspace
+env -u NODE_OPTIONS ./node_modules/.bin/tsc --noEmit
+env -u NODE_OPTIONS pnpm lint                # 0e/0w
+env -u NODE_OPTIONS pnpm build
+```
+
+手動確認（local e2e）:
+- 外観 tab でライト/ダーク/システム切替 → `<html data-theme>` が即時反映
+- reload しても選択が永続（localStorage）
+- 「システム」選択時に OS のダーク/ライト切替へ追従
+- 初回ロード（未選択）で FOUC が出ない（自前 no-flash inline script）
+- 主要ページ（feed / profile / settings / footprints / messages）が light で破綻しない
+
+成功基準:
+- 3 択が機能し永続・OS 追従する
+- 既存コンポーネントが light で読める（コントラスト破綻なし）
+- dark の見た目は現状から不変

--- a/services/frontend/workspace/src/app/globals.css
+++ b/services/frontend/workspace/src/app/globals.css
@@ -58,6 +58,21 @@
     0 4px 6px -4px rgb(168 85 247 / 0.2);
 }
 
+/* Light theme: override only the semantic aliases. Neutral/brand scales,
+   gradients, and radius stay shared in :root (dark default). */
+[data-theme="light"] {
+  --color-bg: #ffffff;
+  --color-surface: var(--color-neutral-100);
+  --color-bg-secondary: var(--color-neutral-200);
+  --color-divider: var(--color-neutral-200);
+  --color-border: var(--color-neutral-300);
+  --color-text-primary: var(--color-neutral-900);
+  --color-text-secondary: var(--color-neutral-500);
+  --color-text-muted: var(--color-neutral-400);
+  --color-input-bg: var(--color-neutral-100);
+  /* accent/brand stay shared with :root — no override needed */
+}
+
 /* root font-size 15px — spec §3.2 が全 rem token の前提とする */
 html {
   font-size: 93.75%;

--- a/services/frontend/workspace/src/app/globals.css
+++ b/services/frontend/workspace/src/app/globals.css
@@ -71,6 +71,10 @@
   --color-text-muted: var(--color-neutral-400);
   --color-input-bg: var(--color-neutral-100);
   /* accent/brand stay shared with :root — no override needed */
+  /* error needs a darker red for AA contrast on light surfaces; the :root
+     #f87171 is ~3:1 on white. warning/info/success keep their interim values
+     (spec §10) — they are not yet surfaced on light backgrounds. */
+  --color-error: #dc2626;
 }
 
 /* root font-size 15px — spec §3.2 が全 rem token の前提とする */

--- a/services/frontend/workspace/src/app/layout.tsx
+++ b/services/frontend/workspace/src/app/layout.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
 import { AuthProvider } from "@/modules/identity/hooks/useAuth";
 import { SWRProvider } from "@/components/providers/SWRProvider";
 import { AppShell } from "@/components/shell";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
 
 export default function RootLayout({
   children,
@@ -26,11 +27,22 @@ export default function RootLayout({
   return (
     <html lang="ja" className={notoSansJP.variable} suppressHydrationWarning>
       <body className="antialiased bg-bg">
-        <AuthProvider>
-          <SWRProvider>
-            <AppShell>{children}</AppShell>
-          </SWRProvider>
-        </AuthProvider>
+        {/* Blocking script: set data-theme before first paint to prevent a theme
+            flash. A raw <script> as the first body child is intentional —
+            next/script beforeInteractive lands in <head> and is not guaranteed
+            to run before the body paints. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("theme")||"system";var d=t==="dark"||(t==="system"&&window.matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.dataset.theme=d?"dark":"light";}catch(e){}})();`,
+          }}
+        />
+        <ThemeProvider>
+          <AuthProvider>
+            <SWRProvider>
+              <AppShell>{children}</AppShell>
+            </SWRProvider>
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/services/frontend/workspace/src/app/settings/page.tsx
+++ b/services/frontend/workspace/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { AreaSettings } from "@/modules/profile/components/AreaSettings";
 import { PrivacySettings } from "@/modules/profile/components/PrivacySettings";
 import { AccountSettings } from "@/modules/profile/components/AccountSettings";
 import { NotificationSettings } from "@/modules/notifications/components/NotificationSettings";
+import { AppearanceSettings } from "@/modules/profile/components/AppearanceSettings";
 
 export default function SettingsPage() {
   const isHydrated = useAuthStore(selectIsHydrated);
@@ -18,6 +19,7 @@ export default function SettingsPage() {
     { id: "notifications", label: "通知設定" },
     ...(role === "cast" ? [{ id: "area", label: "エリア" }] : []),
     { id: "privacy", label: "プライバシー" },
+    { id: "appearance", label: "外観" },
     { id: "account", label: "アカウント" },
   ];
   const [tab, setTab] = useState("notifications");
@@ -41,6 +43,7 @@ export default function SettingsPage() {
         {tab === "notifications" && <NotificationSettings />}
         {tab === "area" && role === "cast" && <AreaSettings profile={profile} save={saveProfile} />}
         {tab === "privacy" && <PrivacySettings profile={profile} save={saveProfile} />}
+        {tab === "appearance" && <AppearanceSettings />}
         {tab === "account" && <AccountSettings profile={profile} save={saveProfile} />}
       </div>
     </main>

--- a/services/frontend/workspace/src/components/providers/ThemeProvider.tsx
+++ b/services/frontend/workspace/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+export type ThemeChoice = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme";
+
+interface ThemeContextValue {
+  theme: ThemeChoice;
+  setTheme: (t: ThemeChoice) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function applyTheme(choice: ThemeChoice) {
+  const dark =
+    choice === "dark" ||
+    (choice === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+}
+
+function readStoredTheme(): ThemeChoice {
+  if (typeof localStorage === "undefined") return "system";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // Lazy initializer runs on the client only (ThemeProvider is "use client").
+  // On the server, localStorage is undefined and readStoredTheme returns "system".
+  const [theme, setThemeState] = useState<ThemeChoice>(readStoredTheme);
+
+  // Apply on change, and follow the OS while in system mode.
+  useEffect(() => {
+    applyTheme(theme);
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme("system");
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [theme]);
+
+  const setTheme = useCallback((t: ThemeChoice) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    setThemeState(t);
+  }, []);
+
+  return <ThemeContext.Provider value={{ theme, setTheme }}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/services/frontend/workspace/src/components/ui/toggle.tsx
+++ b/services/frontend/workspace/src/components/ui/toggle.tsx
@@ -27,14 +27,14 @@ export function Toggle({
       onClick={() => onCheckedChange(!checked)}
       className={cn(
         "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50",
-        checked ? "bg-accent" : "bg-neutral-700",
+        checked ? "bg-accent" : "bg-bg-secondary",
         className
       )}
       {...props}
     >
       <span
         className={cn(
-          "inline-block h-5 w-5 rounded-full bg-white transition-transform",
+          "inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform",
           checked ? "translate-x-5" : "translate-x-0.5"
         )}
       />

--- a/services/frontend/workspace/src/modules/profile/components/AppearanceSettings.tsx
+++ b/services/frontend/workspace/src/modules/profile/components/AppearanceSettings.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { useTheme, type ThemeChoice } from "@/components/providers/ThemeProvider";
+
+const OPTIONS: { value: ThemeChoice; label: string }[] = [
+  { value: "light", label: "ライト" },
+  { value: "dark", label: "ダーク" },
+  { value: "system", label: "システム" },
+];
+
+// useSyncExternalStore with a no-op subscribe returns false on the server
+// and true on the client, preventing hydration mismatches without setState in effects.
+const subscribe = () => () => {};
+
+export function AppearanceSettings() {
+  const { theme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(subscribe, () => true, () => false);
+
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <h2 className="text-sm font-semibold text-text-secondary">テーマ</h2>
+      <div role="radiogroup" aria-label="テーマ" className="flex flex-col gap-2">
+        {OPTIONS.map((opt) => {
+          const selected = mounted && theme === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => setTheme(opt.value)}
+              className={`flex items-center justify-between rounded-md border px-4 py-3 text-left text-sm ${
+                selected
+                  ? "border-accent text-text-primary"
+                  : "border-border text-text-secondary hover:bg-bg-secondary"
+              }`}
+            >
+              <span>{opt.label}</span>
+              <span
+                aria-hidden="true"
+                className={`h-4 w-4 rounded-full border ${
+                  selected ? "border-accent bg-accent" : "border-border"
+                }`}
+              />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
ダーク一択だった frontend に **light テーマ**を追加し、Settings に **外観 tab（ライト / ダーク / システム）** を設置（#101）。

- **自前実装・依存追加なし**: no-flash inline script（body 先頭、paint 前に `<html data-theme>` 確定）+ `ThemeProvider`/`useTheme`（localStorage `theme` 永続化、`matchMedia` で system 追従）。
  - next-themes は ~13ヶ月 dormant のため不採用。@wrksz/themes も評価したが 3ヶ月・単独メンテナで production 依存には未成熟と判断。
- **token 機構**: `[data-theme="light"]` で semantic alias のみ上書き（neutral/brand/gradient は共通）。dark は不変。
- **外観 tab**: `AppearanceSettings`（3 radio、`useSyncExternalStore` で SSR-safe な mounted guard）。
- **color audit**: 19 箇所中 light で破綻する `toggle.tsx` の unchecked track のみ semantic token 化（他は accent/gradient 上の white・modal scrim で据え置き）。
- light の error 色を AA 安全値（#dc2626）に（白背景でのフォームエラー可読性）。

## Design
- spec: `docs/superpowers/specs/2026-06-19-theme-switcher-design.md`
- plan: `docs/superpowers/plans/2026-06-19-theme-switcher.md`

## Test Plan
- [x] `tsc --noEmit` clean / `pnpm lint` 0e/0w / `pnpm build` ✓ Compiled（全コミットで green）
- [ ] 手動（local e2e）: 外観 tab で 3 値切替 → `<html data-theme>` 即時反映 / reload 永続 / システムで OS 追従 / FOUC なし / 主要ページが light で可読 / dark は不変

## Backlog ref
handoff doc Section 5 B: `#101 Settings 外観 tab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced light theme as an alternative to the existing dark theme
  * Added "Appearance" tab in Settings to select between light, dark, or system-follow modes
  * Theme preference is automatically saved and persists across sessions
  * System mode follows your OS appearance settings

* **Chores**
  * Updated documentation with theme switcher implementation plan and design specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->