### PR TITLE
chore(profile): rename legacy portfolio schema to profile

### DIFF
--- a/docs/superpowers/2026-06-18-session-handoff.md
+++ b/docs/superpowers/2026-06-18-session-handoff.md
@@ -180,7 +180,7 @@ handoff doc Section 5 A の backlog を A 路線で消化中。
 | 項目 | Memo |
 |---|---|
 | ~~`cast_repository.rb` の `is_online?` / `online_cast_ids` / `list_casts_with_filters`~~ | ✅ **完了** (本 PR)。裏取りの結果 writer も caller も無い完全な dead code だった (「書き込んでる」は不正確)。4 メソッド + `schedules` relation 削除 + `offer.schedules` テーブル drop migration。`offer.plans` は別 concern で残置 |
-| `portfolio.profiles` 旧 DB schema | profile P3-P4 で論理的に `profiles` に統合済だが、物理テーブルは `portfolio.profiles` 名で残る (rename = 高コスト migration deferred)。実害なしだが命名汚染 |
+| ~~`portfolio.profiles` 旧 DB schema~~ | ✅ **完了** (本 PR)。実は profile slice の **全 10 テーブルが `portfolio` schema に同居**していた (単独テーブルでなく schema 全体)。「高コスト migration」の据え置き理由は**誤り** — `ALTER SCHEMA portfolio RENAME TO profile` は metadata-only の瞬時 op、FK 自動追従、cross-schema FK ゼロ。コード変更は 10 relation 宣言の `portfolio__`→`profile__` のみ。`portfolio` schema 消滅 |
 | ~~protoc-gen-es version pin~~ | ✅ **#755 完了** (caret → exact `2.12.0` pin。`@bufbuild/buf`/grpc-tools と同方針) |
 
 ## 6. Quick-Start for Next Session

--- a/services/monolith/workspace/config/db/migrate/20260620000000_rename_portfolio_schema_to_profile.rb
+++ b/services/monolith/workspace/config/db/migrate/20260620000000_rename_portfolio_schema_to_profile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Renames the legacy `portfolio` schema to `profile`. All Profile-slice tables
+# (casts, guests, areas, profiles, ...) physically lived in `portfolio`, a
+# leftover from the portfolio→profile domain rename. This is a metadata-only
+# operation (no data movement); FKs and indexes follow the schema automatically.
+ROM::SQL.migration do
+  up do
+    run "ALTER SCHEMA portfolio RENAME TO profile"
+  end
+
+  down do
+    run "ALTER SCHEMA profile RENAME TO portfolio"
+  end
+end

--- a/services/monolith/workspace/slices/profile/relations/areas.rb
+++ b/services/monolith/workspace/slices/profile/relations/areas.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class Areas < Profile::DB::Relation
-      schema(:"portfolio__areas", as: :areas, infer: false) do
+      schema(:"profile__areas", as: :areas, infer: false) do
         attribute :id, Types::String
         attribute :prefecture, Types::String
         attribute :name, Types::String

--- a/services/monolith/workspace/slices/profile/relations/cast_areas.rb
+++ b/services/monolith/workspace/slices/profile/relations/cast_areas.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class CastAreas < Profile::DB::Relation
-      schema(:"portfolio__cast_areas", as: :cast_areas, infer: false) do
+      schema(:"profile__cast_areas", as: :cast_areas, infer: false) do
         attribute :cast_user_id, Types::String
         attribute :area_id, Types::String
         attribute :created_at, Types::Time

--- a/services/monolith/workspace/slices/profile/relations/cast_gallery_media.rb
+++ b/services/monolith/workspace/slices/profile/relations/cast_gallery_media.rb
@@ -3,7 +3,7 @@
 module Profile
   module Relations
     class CastGalleryMedia < Profile::DB::Relation
-      schema(:"portfolio__cast_gallery_media", as: :cast_gallery_media, infer: false) do
+      schema(:"profile__cast_gallery_media", as: :cast_gallery_media, infer: false) do
         attribute :id, Types::String
         attribute :cast_user_id, Types::String
         attribute :media_id, Types::String

--- a/services/monolith/workspace/slices/profile/relations/cast_genres.rb
+++ b/services/monolith/workspace/slices/profile/relations/cast_genres.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class CastGenres < Profile::DB::Relation
-      schema(:"portfolio__cast_genres", as: :cast_genres, infer: false) do
+      schema(:"profile__cast_genres", as: :cast_genres, infer: false) do
         attribute :id, Types::String
         attribute :cast_user_id, Types::String
         attribute :genre_id, Types::String

--- a/services/monolith/workspace/slices/profile/relations/casts.rb
+++ b/services/monolith/workspace/slices/profile/relations/casts.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class Casts < Profile::DB::Relation
-      schema(:"portfolio__casts", as: :casts, infer: false) do
+      schema(:"profile__casts", as: :casts, infer: false) do
         attribute :user_id, Types::String  # UUID
         attribute :name, Types::String
         attribute :bio, Types::String

--- a/services/monolith/workspace/slices/profile/relations/genres.rb
+++ b/services/monolith/workspace/slices/profile/relations/genres.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class Genres < Profile::DB::Relation
-      schema(:"portfolio__genres", as: :genres, infer: false) do
+      schema(:"profile__genres", as: :genres, infer: false) do
         attribute :id, Types::String
         attribute :name, Types::String
         attribute :slug, Types::String

--- a/services/monolith/workspace/slices/profile/relations/guest_prefectures.rb
+++ b/services/monolith/workspace/slices/profile/relations/guest_prefectures.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class GuestPrefectures < Profile::DB::Relation
-      schema(:"portfolio__guest_prefectures", as: :guest_prefectures, infer: false) do
+      schema(:"profile__guest_prefectures", as: :guest_prefectures, infer: false) do
         attribute :guest_user_id, Types::String
         attribute :prefecture, Types::String
         attribute :created_at, Types::Time

--- a/services/monolith/workspace/slices/profile/relations/guests.rb
+++ b/services/monolith/workspace/slices/profile/relations/guests.rb
@@ -3,7 +3,7 @@
 module Profile
   module Relations
     class Guests < Profile::DB::Relation
-      schema(:"portfolio__guests", as: :guests, infer: false) do
+      schema(:"profile__guests", as: :guests, infer: false) do
         attribute :user_id, Types::String # UUID
         attribute :name, Types::String
         attribute :avatar_media_id, Types::String

--- a/services/monolith/workspace/slices/profile/relations/profile_areas.rb
+++ b/services/monolith/workspace/slices/profile/relations/profile_areas.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class ProfileAreas < Profile::DB::Relation
-      schema(:"portfolio__profile_areas", as: :profile_areas, infer: false) do
+      schema(:"profile__profile_areas", as: :profile_areas, infer: false) do
         attribute :profile_id, Types::String
         attribute :area_id, Types::String
         attribute :created_at, Types::Time

--- a/services/monolith/workspace/slices/profile/relations/profiles.rb
+++ b/services/monolith/workspace/slices/profile/relations/profiles.rb
@@ -1,7 +1,7 @@
 module Profile
   module Relations
     class Profiles < Profile::DB::Relation
-      schema(:"portfolio__profiles", as: :profiles, infer: false) do
+      schema(:"profile__profiles", as: :profiles, infer: false) do
         attribute :account_id, Types::String       # UUID, PK = identity.Account
         attribute :username, Types::String.optional
         attribute :display_name, Types::String

--- a/services/monolith/workspace/spec/slices/profile/relations/casts_spec.rb
+++ b/services/monolith/workspace/spec/slices/profile/relations/casts_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Profile::Relations::Casts", type: :database do
   end
 
   it "maps to the correct table" do
-    expect(relation.name.dataset).to eq(:"portfolio__casts")
+    expect(relation.name.dataset).to eq(:"profile__casts")
   end
 
   it "defines associations" do


### PR DESCRIPTION
## Summary
profile slice の **全 10 テーブルが legacy `portfolio` schema に同居**していた（offer 削除 / portfolio→profile 改名の残骸）。schema 名を slice に合わせて `profile` へ rename し、命名の負の遺産を解消。

裏取りで handoff doc の「`portfolio.profiles` は単独テーブル / 高コスト migration」は**不正確**と判明:
- 実態は schema 全体（casts, guests, areas, profiles, cast_*, genres, profile_areas）。
- `ALTER SCHEMA portfolio RENAME TO profile` は **metadata-only の瞬時 op**（データ移動なし、FK/index 自動追従）。portfolio への cross-schema FK はゼロ。
- コード変更は profile slice の **10 relation 宣言の `portfolio__`→`profile__`** のみ（生 SQL の cross-schema 参照なし、他スライスは relation/repo 抽象経由）。

## Changes
- migration `20260620000000_rename_portfolio_schema_to_profile`（up: rename / down: 逆 rename）
- 10 relation 宣言を `schema(:"profile__*")` に
- `casts_spec` の dataset assertion を `profile__casts` に

## Test Plan
- [x] test DB に migration 適用
- [x] `bundle exec rspec`（全 suite）— profile slice + cross-slice 全 green
- [ ] 既知の pre-existing 2 失敗（identity JWT interceptor / sms_verification id default）は本変更と無関係の環境起因（#756 時と同一）

## Notes
- `config/db/structure.sql` 未更新（運用どおり + ローカル pg_dump version mismatch）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Completed backend database schema modernization through comprehensive infrastructure reorganization and standardization efforts. System-wide schema naming conventions have been updated and applied throughout the entire codebase with all internal dependencies properly adjusted. All related testing infrastructure, verification processes, and test assertions have been correspondingly updated.

* **Chores**
  * Updated internal technical documentation reflecting completed infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->