### PR TITLE
fix(identity): distinguish ACCOUNT_LOCKED from invalid credentials

### DIFF
--- a/services/frontend/workspace/src/app/api/identity/sign-in/route.ts
+++ b/services/frontend/workspace/src/app/api/identity/sign-in/route.ts
@@ -31,6 +31,26 @@ export async function POST(req: NextRequest) {
     });
     return res;
   } catch (error: unknown) {
+    // ACCOUNT_LOCKED arrives as FAILED_PRECONDITION with body "ACCOUNT_LOCKED:<seconds>".
+    // Surface as 423 Locked + a distinct payload so the UI shows a real wait
+    // message instead of letting the user keep retrying through the lockout window.
+    if (isConnectError(error) && error.code === GrpcCode.FAILED_PRECONDITION) {
+      const raw = error.rawMessage || error.message || "";
+      const match = raw.match(/ACCOUNT_LOCKED:(\d+)/);
+      const retryAfterSeconds = match ? parseInt(match[1], 10) : null;
+      const minutes = retryAfterSeconds != null ? Math.max(1, Math.ceil(retryAfterSeconds / 60)) : null;
+      console.warn(`Login locked: retryAfter=${retryAfterSeconds}s`);
+      return NextResponse.json(
+        {
+          error: "ACCOUNT_LOCKED",
+          message: minutes != null
+            ? `ログイン失敗が続いたためアカウントを一時的にロックしています。約 ${minutes} 分後にもう一度お試しください。`
+            : "ログイン失敗が続いたためアカウントを一時的にロックしています。しばらく時間をおいてお試しください。",
+          retryAfterSeconds,
+        },
+        { status: 423 }
+      );
+    }
     // Code 16 is Unauthenticated (ConnectRPC/gRPC)
     if (isConnectError(error) && error.code === GrpcCode.UNAUTHENTICATED) {
       // Clean log for expected failures

--- a/services/frontend/workspace/src/lib/grpc-errors.ts
+++ b/services/frontend/workspace/src/lib/grpc-errors.ts
@@ -5,6 +5,7 @@ export const GrpcCode = {
   NOT_FOUND: 5,
   ALREADY_EXISTS: 6,
   PERMISSION_DENIED: 7,
+  FAILED_PRECONDITION: 9,
   UNAUTHENTICATED: 16,
 } as const;
 
@@ -13,6 +14,7 @@ const GRPC_TO_HTTP: Record<number, number> = {
   [GrpcCode.NOT_FOUND]: 404,
   [GrpcCode.ALREADY_EXISTS]: 409,
   [GrpcCode.PERMISSION_DENIED]: 403,
+  [GrpcCode.FAILED_PRECONDITION]: 422,
   [GrpcCode.UNAUTHENTICATED]: 401,
 };
 

--- a/services/frontend/workspace/src/modules/identity/hooks/useAuth.tsx
+++ b/services/frontend/workspace/src/modules/identity/hooks/useAuth.tsx
@@ -189,7 +189,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       body: JSON.stringify({ phoneNumber, password, role: loginRole }),
     });
     const data = await res.json();
-    if (!res.ok) throw new Error(data.error || "ログインに失敗しました");
+    // 423 Locked carries a friendly message in `data.message` (with retry minutes);
+    // fall back to `data.error` for other failure codes.
+    if (!res.ok) throw new Error(data.message || data.error || "ログインに失敗しました");
 
     if (!data.account?.id) {
       throw new Error("ログインに失敗しました");

--- a/services/monolith/workspace/slices/identity/grpc/handler.rb
+++ b/services/monolith/workspace/slices/identity/grpc/handler.rb
@@ -83,6 +83,14 @@ module Identity
         else
           raise GRPC::BadStatus.new(GRPC::Core::StatusCodes::UNAUTHENTICATED, "Invalid credentials or role mismatch")
         end
+      rescue Identity::UseCases::Auth::Login::LockedError => e
+        # Distinct from UNAUTHENTICATED so the BFF/UI can tell the user to wait
+        # instead of letting them keep retrying wrong passwords through the
+        # 15-minute lockout window. Body carries the remaining seconds.
+        raise GRPC::BadStatus.new(
+          GRPC::Core::StatusCodes::FAILED_PRECONDITION,
+          "ACCOUNT_LOCKED:#{e.retry_after_seconds}"
+        )
       rescue Errors::ValidationError => e
         raise GRPC::BadStatus.new(GRPC::Core::StatusCodes::INVALID_ARGUMENT, e.message)
       end

--- a/services/monolith/workspace/slices/identity/use_cases/auth/login.rb
+++ b/services/monolith/workspace/slices/identity/use_cases/auth/login.rb
@@ -11,6 +11,17 @@ module Identity
         MAX_FAILED_LOGIN_ATTEMPTS = 5
         LOCKOUT_DURATION_SECONDS = 60 * 15
 
+        # Raised when the user record is in a brute-force lockout window.
+        # Carries the remaining seconds so callers can show a precise wait time.
+        class LockedError < StandardError
+          attr_reader :retry_after_seconds, :locked_until
+          def initialize(locked_until:)
+            @locked_until = locked_until
+            @retry_after_seconds = [(locked_until - Time.now).to_i, 0].max
+            super("Account is temporarily locked")
+          end
+        end
+
         include Identity::Deps[
           repo: "repositories.user_repository",
           refresh_repo: "repositories.refresh_token_repository",
@@ -27,7 +38,9 @@ module Identity
           user = repo.find_by_phone_number(phone_number)
 
           return nil unless user
-          return nil if user.locked_until && user.locked_until > Time.now
+          if user.locked_until && user.locked_until > Time.now
+            raise LockedError.new(locked_until: user.locked_until)
+          end
 
           unless BCrypt::Password.new(user.password_digest) == password
             repo.record_failed_login(user.id)

--- a/services/monolith/workspace/spec/slices/identity/use_cases/auth/login_spec.rb
+++ b/services/monolith/workspace/spec/slices/identity/use_cases/auth/login_spec.rb
@@ -151,10 +151,14 @@ RSpec.describe Identity::UseCases::Auth::Login do
         allow(repo).to receive(:find_by_phone_number).with(phone_number).and_return(user)
       end
 
-      it "returns nil without checking the password" do
+      it "raises LockedError without checking the password, carrying retry_after_seconds" do
         expect(BCrypt::Password).not_to receive(:new)
-        result = use_case.call(phone_number: phone_number, password: password, role: role)
-        expect(result).to be_nil
+        expect {
+          use_case.call(phone_number: phone_number, password: password, role: role)
+        }.to raise_error(Identity::UseCases::Auth::Login::LockedError) { |e|
+          # 600 seconds left at definition; allow a couple seconds slack for test runtime.
+          expect(e.retry_after_seconds).to be_between(595, 600).inclusive
+        }
       end
     end
 


### PR DESCRIPTION
## Status

Ready for review. Bug surfaced by dogfood e2e flow.

## Bug

\`Login\` use_case returned \`nil\` for both wrong-password and lockout, so the gRPC handler converted both to \`UNAUTHENTICATED\` and the BFF returned the same 401 + 「電話番号または認証コードが正しくありません」. A user inside the 15-minute lockout window kept retrying without any signal that the next attempts were guaranteed to fail. Backend lockout was working (\`identity.users.locked_until\` was set, attempts after lockout never touched bcrypt), but the user-facing distinction was missing.

## Fix

| Layer | Change |
|---|---|
| Use case | New \`Login::LockedError\` carrying \`retry_after_seconds\`; raised instead of returning nil when \`locked_until > Time.now\` |
| Handler | Rescues \`LockedError\` → \`GRPC::FAILED_PRECONDITION\` with body \`ACCOUNT_LOCKED:<seconds>\` |
| BFF | \`sign-in/route.ts\` recognizes \`FAILED_PRECONDITION\` → HTTP **423 Locked** + \`{error: ACCOUNT_LOCKED, message, retryAfterSeconds}\` |
| BFF lib | \`grpc-errors.ts\` adds \`FAILED_PRECONDITION: 9\` constant + 422 default mapping |
| Hook | \`useAuth.login\` throws \`data.message ?? data.error\` so the login form shows 「約 15 分後にもう一度お試しください」 instead of the generic copy |

## Verification

- Identity rspec: 73 examples, 1 failure (pre-existing) — baseline maintained; spec was updated to assert \`LockedError\` is raised with \`retry_after_seconds\` in the 595-600 range
- \`tsc --noEmit\` clean, \`pnpm lint\` 0e/0w, \`pnpm build\` green
- Dogfood e2e re-run after the fix: 6th wrong-password attempt now returns \`HTTP 423 / {error: ACCOUNT_LOCKED, message: "ログイン失敗が続いたためアカウントを一時的にロックしています。約 15 分後にもう一度お試しください。", retryAfterSeconds: 899}\` instead of the indistinguishable 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-in now clearly reports when an account is temporarily locked, including an estimated wait time before retrying.
  * Login errors can now display a more helpful message to users instead of a generic failure.

* **Bug Fixes**
  * Locked accounts are no longer treated as standard authentication failures.
  * The app now handles lockout responses consistently across the sign-in flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->