### PR TITLE
fix(karte): aggregate() must strip the relation's default ORDER BY

### DIFF
--- a/services/monolith/workspace/slices/karte/repositories/entry_repository.rb
+++ b/services/monolith/workspace/slices/karte/repositories/entry_repository.rb
@@ -42,9 +42,15 @@ module Karte
       end
 
       def aggregate(target_account_id:)
+        # .unordered strips the relation's implicit ORDER BY id that ROM
+        # carries from the schema's primary_key. Without it, the aggregate
+        # query becomes SELECT count(id), avg(rating) ... ORDER BY id, and
+        # Postgres rejects it with PG::GroupingError because id is not
+        # grouped on or wrapped in an aggregate.
         row = entry_records
           .where(target_account_id: target_account_id)
           .dataset
+          .unordered
           .select { [count(id).as(:count), avg(rating).as(:avg)] }
           .first
         {

--- a/services/monolith/workspace/spec/slices/karte/repositories/entry_repository_spec.rb
+++ b/services/monolith/workspace/spec/slices/karte/repositories/entry_repository_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "slices/karte/repositories/entry_repository"
+
+# Regression: PG::GroupingError when aggregate() runs against a target that
+# has at least one entry. Pure-double specs let it slip because they don't
+# materialise the relation's default ORDER BY id, which collides with the
+# SELECT count(id), avg(rating) ... shape Postgres requires aggregates to use.
+RSpec.describe Karte::Repositories::EntryRepository, type: :database do
+  subject(:repo) { described_class.new }
+
+  let(:author_id) { SecureRandom.uuid_v7 }
+  let(:target_id) { SecureRandom.uuid_v7 }
+
+  describe "#aggregate" do
+    context "when the target has no entries" do
+      it "returns zeros" do
+        result = repo.aggregate(target_account_id: target_id)
+        expect(result).to eq(count: 0, avg_rating: 0.0)
+      end
+    end
+
+    context "when the target has entries" do
+      before do
+        repo.create(author_account_id: author_id, target_account_id: target_id, rating: 5, body: "good")
+        repo.create(author_account_id: SecureRandom.uuid_v7, target_account_id: target_id, rating: 3, body: nil)
+      end
+
+      it "returns count and avg_rating against the real database" do
+        result = repo.aggregate(target_account_id: target_id)
+        expect(result[:count]).to eq(2)
+        expect(result[:avg_rating]).to be_within(0.001).of(4.0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Status

Ready for review. Production bug surfaced by dogfood e2e.

## Bug

\`Karte::Repositories::EntryRepository#aggregate\` issues:

\`\`\`sql
SELECT count(id) AS count, avg(rating) AS avg
FROM karte.entries
WHERE target_account_id = ...
\`\`\`

ROM relations carry an implicit \`ORDER BY id\` from the schema's \`primary_key :id\`. The aggregate query inherits it, becoming:

\`\`\`sql
SELECT count(id), avg(rating) ... WHERE ... ORDER BY id
\`\`\`

Postgres rejects this with \`PG::GroupingError: column "entries.id" must appear in the GROUP BY clause or be used in an aggregate function\`. Result: \`karte.list_entries_by_target\` returned **HTTP 500 to any target with one or more karte entries**, breaking the read side of MVP 柱 B.

## Why it slipped past unit specs

\`list_entries_by_target_spec\` doubles \`entry_repo.aggregate\` and never materialises the relation's default ORDER BY. The real-DB SQL shape is invisible at the use_case layer.

## Fix

Append \`.unordered\` to the dataset chain in \`aggregate()\` to strip the implicit ORDER BY before the aggregate select is applied. One line.

## Regression guard

New \`spec/slices/karte/repositories/entry_repository_spec.rb\` with \`type: :database\`:

- empty target → \`{count: 0, avg_rating: 0.0}\`
- 2 rows persisted → \`count: 2, avg_rating: 4.0\`

Both run against the real Postgres harness, so any future change that re-introduces ORDER BY into the aggregate dataset will fail the suite.

## Verification

- \`bundle exec rspec spec/slices/karte\` → 35 examples, 0 failures
- dogfood e2e re-run with the fix: karte tab on guest profile loads aggregate + entry list with HTTP 200, no PG::GroupingError in monolith log

🤖 Generated with [Claude Code](https://claude.com/claude-code)