### PR TITLE
fix(discovery): present profiles through ProfilePresenter before proto assign

### DIFF
--- a/services/monolith/workspace/slices/discovery/grpc/discovery_handler.rb
+++ b/services/monolith/workspace/slices/discovery/grpc/discovery_handler.rb
@@ -39,7 +39,7 @@ module Discovery
           role_filter: role_filter
         )
         ::Discovery::V1::SearchUsersResponse.new(
-          profiles: result[:profiles],
+          profiles: result[:profiles].map { |p| present_profile(p) },
           next_cursor: result[:next_cursor] || "",
           has_more: result[:has_more]
         )
@@ -56,7 +56,7 @@ module Discovery
           cursor: cursor
         )
         ::Discovery::V1::SuggestUsersResponse.new(
-          profiles: result[:profiles],
+          profiles: result[:profiles].map { |p| present_profile(p) },
           next_cursor: result[:next_cursor] || "",
           has_more: result[:has_more]
         )
@@ -100,6 +100,26 @@ module Discovery
       end
 
       private
+
+      # User-list responses carry profile.v1.Profile submessages, but the
+      # Profile use_cases return Profile::Structs::Profile. Without an
+      # explicit presenter step the proto layer raised
+      # Google::Protobuf::TypeError: Invalid type Profile::Structs::Profile
+      # to assign to submessage field 'profiles'.
+      def present_profile(profile)
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
+      end
 
       # Default period is "week" when the RPC sends UNSPECIFIED — matches the
       # /ranking surface default tab in D2.


### PR DESCRIPTION
## Status

Ready for review. Production bug surfaced by dogfood e2e.

## Bug

\`SuggestUsers\` and \`SearchUsers\` handlers assigned \`Profile::Structs::Profile\` directly into the response submessage:

\`\`\`ruby
::Discovery::V1::SuggestUsersResponse.new(
  profiles: result[:profiles],   # <- list of Profile::Structs::Profile
  ...
)
\`\`\`

Protobuf rejected it with:

\`\`\`
Google::Protobuf::TypeError: Invalid type Profile::Structs::Profile to assign to submessage field 'profiles'
\`\`\`

Result: **home feed's おすすめ rail returned 500 to every viewer** that had at least one opposite-role profile to suggest. \`/search\` users tab had the same shape and would have failed once anyone typed a query.

## Why it slipped past specs

Unit specs for the use_case work on plain Ruby hashes and never reach the proto layer. Handler specs (if any) would need real Profile structs to surface the encoding error.

## Fix

Both handlers now go through a shared \`present_profile\` helper that calls \`ProfilePresenter.to_proto(profile, role: ...)\`, mirroring identity \`users.role\` onto the proto so the UI does not have to infer (same pattern PR #767 introduced for \`profile_handler\`).

\`area_records\` / \`media_files\` are intentionally left empty — the discovery rail only needs handle + display + \`avatar_url\` (which is a column on the profile struct itself).

## Verification

- \`bundle exec rspec spec/slices/discovery spec/slices/identity\` → 77 examples, 1 failure (pre-existing sms_verification_repository_spec failure unchanged)
- Live re-test after the fix: \`GET /api/discovery/suggested-users?limit=10\` returns **HTTP 200**, monolith log shows \`suggest_users ... status: OK\` instead of the prior \`Invalid type\` TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)