### PR TITLE
fix(social): present profiles through ProfilePresenter before proto assign

### DIFF
--- a/services/monolith/workspace/slices/social/grpc/block_handler.rb
+++ b/services/monolith/workspace/slices/social/grpc/block_handler.rb
@@ -45,7 +45,7 @@ module Social
 
         result = list_blocked_uc.call(blocker_id: current_user_id, limit: limit, cursor: cursor)
         ::Social::V1::ListBlockedResponse.new(
-          profiles: result[:profiles],
+          profiles: result[:profiles].map { |p| present_profile(p) },
           next_cursor: result[:next_cursor] || "",
           has_more: result[:has_more]
         )
@@ -58,6 +58,26 @@ module Social
           target_account_ids: request.message.target_account_ids.to_a
         )
         ::Social::V1::GetBlockStatusResponse.new(blocked: statuses)
+      end
+
+      private
+
+      # Same Struct→proto fix as PR #770 (discovery). list_blocked assigns
+      # profile structs straight to repeated profile.v1.Profile and would
+      # otherwise raise Google::Protobuf::TypeError.
+      def present_profile(profile)
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
       end
     end
   end

--- a/services/monolith/workspace/slices/social/grpc/follow_handler.rb
+++ b/services/monolith/workspace/slices/social/grpc/follow_handler.rb
@@ -78,7 +78,7 @@ module Social
 
         result = list_following_uc.call(account_id: account_id, limit: limit, cursor: cursor)
         ::Social::V1::ListFollowingResponse.new(
-          profiles: result[:profiles],
+          profiles: result[:profiles].map { |p| present_profile(p) },
           next_cursor: result[:next_cursor] || "",
           has_more: result[:has_more]
         )
@@ -92,7 +92,7 @@ module Social
 
         result = list_followers_uc.call(account_id: account_id, limit: limit, cursor: cursor)
         ::Social::V1::ListFollowersResponse.new(
-          profiles: result[:profiles],
+          profiles: result[:profiles].map { |p| present_profile(p) },
           next_cursor: result[:next_cursor] || "",
           has_more: result[:has_more]
         )
@@ -105,7 +105,7 @@ module Social
 
         result = list_pending_follow_requests_uc.call(account_id: current_user_id, limit: limit, cursor: cursor)
         ::Social::V1::ListPendingFollowRequestsResponse.new(
-          profiles: result[:profiles],
+          profiles: result[:profiles].map { |p| present_profile(p) },
           next_cursor: result[:next_cursor] || "",
           has_more: result[:has_more]
         )
@@ -138,6 +138,26 @@ module Social
       end
 
       private
+
+      # Same Struct→proto fix as PR #770 (discovery). list_following /
+      # list_followers / list_pending_follow_requests all assign profile
+      # structs straight to repeated profile.v1.Profile fields and would
+      # otherwise raise Google::Protobuf::TypeError: Invalid type
+      # Profile::Structs::Profile to assign to submessage field 'profiles'.
+      def present_profile(profile)
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
+      end
 
       def status_to_enum(status)
         case status


### PR DESCRIPTION
## Status

Ready for review. Same shape as PR #770 (discovery), broader sweep across the social slice. Surfaced by dogfood round 4.

## Bug

Follow + block handlers still assigned \`Profile::Structs::Profile\` straight into:

- \`ListFollowingResponse.profiles\`
- \`ListFollowersResponse.profiles\`
- \`ListPendingFollowRequestsResponse.profiles\`
- \`ListBlockedResponse.profiles\`

Protobuf rejected the assignment with \`Google::Protobuf::TypeError: Invalid type Profile::Structs::Profile to assign to submessage field 'profiles'\`. \`/api/social/following\` intermittently returned 500 once a viewer had a following row; list_followers / list_blocked / pending requests would have failed the same way. PR #770 fixed the おすすめ rail, but the same pattern in social slice was missed.

## Fix

Each handler gets its own \`present_profile\` / \`role_for\` / \`identity_user_repo\` helper trio that goes through \`ProfilePresenter.to_proto(profile, role: ...)\`, mirroring \`identity.users.role\` onto the proto (same pattern as PR #767 / #770).

Inline copies in both handlers rather than a shared module — two call sites isn't enough to justify cross-slice coupling. If a third slice needs the same shape, lift to a concern.

## Verification

- \`bundle exec rspec spec/slices/social spec/slices/identity\` → 75 examples, 1 failure (pre-existing sms_verification_repository_spec unchanged)
- Live re-test after the fix: cast2 follows cast1 → home reloads → \`/api/social/following\` returns **3/3 HTTP 200**, monolith log has **zero ERROR rows** (was 1× \`Invalid type\` per following load before)

## Sweep summary

Cross-slice \`grep\` after #770 to find any other handler doing \`profiles: result[:profiles]\` without \`.map { ... presenter }\` returned **only these two files**. Bookmarks / Messaging / Footprints / Karte don't return profile lists in their proto responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how profile lists are returned in blocked users, following, followers, and pending follow requests.
  * Profiles now include the correct role information and are displayed consistently in these lists.
  * Fixed an issue that could cause profile data to be returned in an incompatible format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->