### PR TITLE
chore(frontend): DOGFOOD_INSECURE_COOKIES escape for local dogfood

### DIFF
--- a/services/frontend/workspace/src/lib/auth/cookies.ts
+++ b/services/frontend/workspace/src/lib/auth/cookies.ts
@@ -20,6 +20,24 @@ const REFRESH_MAX_AGE = 60 * 60 * 24 * 30;
 
 const isProd = process.env.NODE_ENV === "production";
 
+// Dogfood escape: production build (`pnpm build && pnpm start`) sets
+// secure=true, which Chrome refuses to persist over http://localhost.
+// Local headless e2e runs need a way to override that — only that.
+// Why a separate env var instead of relaxing on NODE_ENV alone: we
+// still want a deployed `pnpm start` instance to be secure by default;
+// the escape must be explicit and noisy.
+const insecureCookieEscape = process.env.DOGFOOD_INSECURE_COOKIES === "true";
+if (isProd && insecureCookieEscape) {
+  // Fail-loud at boot so a stray env var in a deployed environment is
+  // obvious in the logs. Never silently downgrade cookie security.
+  console.warn(
+    "[cookies] DOGFOOD_INSECURE_COOKIES=true detected with NODE_ENV=production. " +
+      "Cookies will NOT have the Secure flag. This must ONLY happen in local " +
+      "dogfood — production deploys must keep this env var unset."
+  );
+}
+const cookieSecure = isProd && !insecureCookieEscape;
+
 type CookieOptions = {
   httpOnly: true;
   secure: boolean;
@@ -31,7 +49,7 @@ type CookieOptions = {
 function baseOptions(maxAge: number): CookieOptions {
   return {
     httpOnly: true,
-    secure: isProd,
+    secure: cookieSecure,
     sameSite: "lax",
     path: "/",
     maxAge,


### PR DESCRIPTION
## Status

Ready for review. Tooling-only change.

## Problem

\`pnpm build && pnpm start\` runs the frontend with \`NODE_ENV=production\`, which makes \`setAuthCookies\` emit cookies with the \`Secure\` attribute. Chrome refuses to persist Secure cookies over \`http://localhost\` (the Secure attribute is about the scheme, not whether the origin is a secure context). Result: puppeteer-based local dogfood against a production build couldn't keep its session — sign-in returned 200 but every subsequent request was unauthenticated.

This blocked the dev-mode escape hatch we documented in \`reference_local_e2e_run.md\` after round 5/6 (Next.js dev mode SSE long-polls were tying up the connection pool).

## Fix

Add an opt-in env var \`DOGFOOD_INSECURE_COOKIES=true\` that overrides Secure to false in production builds only:

\`\`\`ts
const insecureCookieEscape = process.env.DOGFOOD_INSECURE_COOKIES === "true";
if (isProd && insecureCookieEscape) {
  console.warn("[cookies] DOGFOOD_INSECURE_COOKIES=true detected with NODE_ENV=production...");
}
const cookieSecure = isProd && !insecureCookieEscape;
\`\`\`

Design choices:

- **Verbose self-documenting name.** \`DOGFOOD_INSECURE_COOKIES\` makes it obvious in any deployment env-var listing what it does.
- **Strict \`=== "true"\` check.** Avoids accidental activation from \`""\`, \`"1"\`, or \`true\` (boolean).
- **No effect outside production.** Dev was already insecure; the escape is a no-op there.
- **\`console.warn\` at module load** when both NODE_ENV=production AND the var is set. A stray var in a deployed environment surfaces loudly in the logs instead of silently downgrading session security.

## Usage

\`\`\`bash
cd services/frontend/workspace
pnpm build
DOGFOOD_INSECURE_COOKIES=true pnpm start
\`\`\`

CI/CD pipelines must keep this var unset. The deployment runbook should explicitly assert that \`DOGFOOD_INSECURE_COOKIES\` is not exported.

## Verification

- tsc clean, lint 0e/0w, build green
- The \`console.warn\` only fires when both NODE_ENV=production AND the var is set — never on a normal production deploy

## Why not just relax on NODE_ENV alone

Because a deployed instance could plausibly be on \`pnpm start\` (e.g., a staging server reachable only over private network without TLS). The escape must be explicit and noisy so operators have to mean it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production cookie setting override that can disable the `Secure` flag in controlled environments.
  * When the override is enabled, the app shows a startup warning so the configuration is visible at boot.

* **Bug Fixes**
  * Preserves secure cookies in production by default, while allowing a deliberate exception for specific deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->