### PR TITLE
chore(frontend): rename DOGFOOD_INSECURE_COOKIES → DEV_HTTP_COOKIES

### DIFF
--- a/services/frontend/workspace/src/lib/auth/cookies.ts
+++ b/services/frontend/workspace/src/lib/auth/cookies.ts
@@ -20,23 +20,23 @@ const REFRESH_MAX_AGE = 60 * 60 * 24 * 30;
 
 const isProd = process.env.NODE_ENV === "production";
 
-// Dogfood escape: production build (`pnpm build && pnpm start`) sets
+// Local-HTTP escape: production build (`pnpm build && pnpm start`) sets
 // secure=true, which Chrome refuses to persist over http://localhost.
 // Local headless e2e runs need a way to override that — only that.
 // Why a separate env var instead of relaxing on NODE_ENV alone: we
 // still want a deployed `pnpm start` instance to be secure by default;
 // the escape must be explicit and noisy.
-const insecureCookieEscape = process.env.DOGFOOD_INSECURE_COOKIES === "true";
-if (isProd && insecureCookieEscape) {
+const allowLocalHttpCookies = process.env.DEV_HTTP_COOKIES === "true";
+if (isProd && allowLocalHttpCookies) {
   // Fail-loud at boot so a stray env var in a deployed environment is
   // obvious in the logs. Never silently downgrade cookie security.
   console.warn(
-    "[cookies] DOGFOOD_INSECURE_COOKIES=true detected with NODE_ENV=production. " +
+    "[cookies] DEV_HTTP_COOKIES=true detected with NODE_ENV=production. " +
       "Cookies will NOT have the Secure flag. This must ONLY happen in local " +
-      "dogfood — production deploys must keep this env var unset."
+      "HTTP dogfood — deployed instances must keep this env var unset."
   );
 }
-const cookieSecure = isProd && !insecureCookieEscape;
+const cookieSecure = isProd && !allowLocalHttpCookies;
 
 type CookieOptions = {
   httpOnly: true;


### PR DESCRIPTION
## Status

Ready for review. Follow-up to #792.

## Why

\`INSECURE\` in the env var name reads as a tooling smell in any deploy config listing — and the word itself can prime an operator to think it's a legitimate knob to flip when something breaks. \`DEV_HTTP_COOKIES\` states the same thing (only the local HTTP dev case needs it) without the negative-language hazard.

## Change

| Before | After |
|---|---|
| \`DOGFOOD_INSECURE_COOKIES=true\` | \`DEV_HTTP_COOKIES=true\` |

Internal binding renamed \`insecureCookieEscape\` → \`allowLocalHttpCookies\`. Console.warn copy and comments updated for the new name. No behavior change.

## Verification

- tsc clean, lint 0e/0w, build green
- Memory `reference_local_e2e_run.md` will be updated post-merge to teach the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)