### PR TITLE
chore(frontend): rename DEV_HTTP_COOKIES → INSECURE_COOKIES

### DIFF
--- a/services/frontend/workspace/src/lib/auth/cookies.ts
+++ b/services/frontend/workspace/src/lib/auth/cookies.ts
@@ -20,23 +20,23 @@ const REFRESH_MAX_AGE = 60 * 60 * 24 * 30;
 
 const isProd = process.env.NODE_ENV === "production";
 
-// Local-HTTP escape: production build (`pnpm build && pnpm start`) sets
-// secure=true, which Chrome refuses to persist over http://localhost.
-// Local headless e2e runs need a way to override that — only that.
-// Why a separate env var instead of relaxing on NODE_ENV alone: we
-// still want a deployed `pnpm start` instance to be secure by default;
-// the escape must be explicit and noisy.
-const allowLocalHttpCookies = process.env.DEV_HTTP_COOKIES === "true";
-if (isProd && allowLocalHttpCookies) {
+// Production build (`pnpm build && pnpm start`) sets secure=true, which
+// Chrome refuses to persist over http://localhost. Local headless e2e
+// runs need a way to override that — only that. The name is deliberately
+// blunt: anyone reviewing a deploy config and seeing INSECURE_COOKIES=true
+// should immediately treat it as a misconfiguration to fix, not a knob to
+// experiment with. Negative language is the guard, not a smell.
+const insecureCookies = process.env.INSECURE_COOKIES === "true";
+if (isProd && insecureCookies) {
   // Fail-loud at boot so a stray env var in a deployed environment is
   // obvious in the logs. Never silently downgrade cookie security.
   console.warn(
-    "[cookies] DEV_HTTP_COOKIES=true detected with NODE_ENV=production. " +
-      "Cookies will NOT have the Secure flag. This must ONLY happen in local " +
-      "HTTP dogfood — deployed instances must keep this env var unset."
+    "[cookies] INSECURE_COOKIES=true detected with NODE_ENV=production. " +
+      "Cookies will NOT have the Secure flag. This must ONLY happen on a " +
+      "local HTTP-only host — deployed instances must keep this env var unset."
   );
 }
-const cookieSecure = isProd && !allowLocalHttpCookies;
+const cookieSecure = isProd && !insecureCookies;
 
 type CookieOptions = {
   httpOnly: true;


### PR DESCRIPTION
## Status

Draft → Ready. Follow-up to #793 reversing the rename direction.

## Why reverse

#793 traded \`INSECURE\` for the neutral \`DEV_HTTP\`, reasoning that the negative language was a tooling smell. After review, the reverse is closer to right:

- \`INSECURE_COOKIES=true\` in any deploy config listing reads to a reviewer as **"this must not be set here"** — the bluntness is the guard.
- A milder name like \`DEV_HTTP_COOKIES\` invites "maybe-it's-fine" reasoning from someone who doesn't know the context.

Negative language deliberately raises the cost of accidental set.

## Change

| Before (#793) | After |
|---|---|
| \`DEV_HTTP_COOKIES=true\` | \`INSECURE_COOKIES=true\` |
| \`allowLocalHttpCookies\` | \`insecureCookies\` |

\`console.warn\` copy + comments updated. Same behavior, same fail-loud at boot when the env var is set with NODE_ENV=production.

## Verification

- tsc clean, lint 0e/0w

🤖 Generated with [Claude Code](https://claude.com/claude-code)