### PR TITLE
fix(social): present profiles through ProfilePresenter for singular fields

### DIFF
--- a/services/monolith/workspace/slices/footprints/grpc/footprints_handler.rb
+++ b/services/monolith/workspace/slices/footprints/grpc/footprints_handler.rb
@@ -56,7 +56,7 @@ module Footprints
           next nil unless profile
 
           ::Footprints::V1::Footprint.new(
-            visitor: profile,
+            visitor: present_profile(profile),
             last_visited_at: to_proto_ts(row[:last_visited_at]),
             is_unread: row[:is_unread],
             visit_count: row[:visit_count]
@@ -83,6 +83,26 @@ module Footprints
       end
 
       private
+
+      # Same Struct→proto fix as PR #770 / #791. Footprint carries a
+      # single profile.v1.Profile field (visitor); the earlier sweep grep
+      # on `profiles:` missed it because the field is singular.
+      # nil-safe: ProfilePresenter.to_proto returns nil for nil input.
+      def present_profile(profile)
+        return nil unless profile
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
+      end
 
       def get_profile
         @get_profile ||= Profile::Slice["use_cases.get_profile"]

--- a/services/monolith/workspace/slices/notifications/grpc/notification_handler.rb
+++ b/services/monolith/workspace/slices/notifications/grpc/notification_handler.rb
@@ -43,7 +43,7 @@ module Notifications
             type: type_to_enum(row.type),
             target_resource_id: row.target_resource_id,
             actor_count: row.actor_count,
-            latest_actor: result[:profiles_by_actor_id][row.latest_actor_id],
+            latest_actor: present_profile(result[:profiles_by_actor_id][row.latest_actor_id]),
             latest_event_at: time_to_timestamp(row.latest_event_at),
             read_at: row.read_at ? time_to_timestamp(row.read_at) : nil,
             target_post_id: row.target_post_id || ""
@@ -108,6 +108,26 @@ module Notifications
       end
 
       private
+
+      # Same Struct→proto fix as PR #770 / #791. Notifications carries a
+      # single profile.v1.Profile field (latest_actor) rather than a
+      # repeated one, so the earlier sweep grep on `profiles:` missed it.
+      # nil-safe: ProfilePresenter.to_proto returns nil for nil input.
+      def present_profile(profile)
+        return nil unless profile
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
+      end
 
       def preferences_to_proto(prefs)
         ::Notifications::V1::NotificationPreferences.new(


### PR DESCRIPTION
## Status

Draft → Ready. Extension of the #770 / #791 fix wave.

## Bug

Two singular \`profile.v1.Profile\` submessage assignments were missed by the earlier sweeps because the grep pattern was \`profiles:\` (plural) only:

- \`notifications.v1.Notification.latest_actor\` (\`notification_handler.rb:46\`)
- \`footprints.v1.Footprint.visitor\` (\`footprints_handler.rb:59\`)

Live monolith logged (surfaced by real Chrome on \`/notifications\` and the footprints visitor list):

\`\`\`
[ListNotifications] gRPC error (13): Invalid type Profile::Structs::Profile
  to assign to submessage field 'latest_actor'.
[ListFootprints] gRPC error (13): Invalid type Profile::Structs::Profile
  to assign to submessage field 'visitor'.
\`\`\`

Any viewer with at least one notification (like/comment/reply/follow event) or one footprint would see the endpoint 500 out.

## Fix

Same \`present_profile\` / \`role_for\` / \`identity_user_repo\` helper trio as \`discovery_handler.rb\` (#770) and the social handlers (#791). One difference: the singular call sites can legitimately receive \`nil\` (deleted actor, missing visitor row), so the helper has an explicit early \`return nil unless profile\` guard.

## Sweep discipline

Also verified the remaining singular candidates in the broader grep:

- \`bookmarks.list_bookmarks\` \`posts:\` — use_case already returns \`Post::V1::Post\` protos (\`ordered_posts = post_ids.filter_map { |id| post_protos_map[id.to_s] }\`), no bug
- \`discovery.search_posts\` / \`rank_posts\` \`posts:\` — same shape as bookmarks, already proto
- \`karte_handler\` \`entry_to_proto\` — helper builds proto explicitly (\`author_username: profile&.username\`, no struct passthrough)
- \`messaging_handler\` \`build_thread_proto\` / \`build_message_proto\` — same, helper builds proto explicitly

## Verification

- \`bundle exec rspec spec/slices/notifications spec/slices/footprints spec/slices/identity\` → 89 examples, 1 failure (pre-existing \`sms_verification_repository_spec:40\` from #766, unrelated)
- Local monolith restart against the fix: \`ListNotifications\` and \`ListFootprints\` return \`status: OK\` in the log where they previously logged \`gRPC error (13): Invalid type Profile::Structs::Profile\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)