### PR TITLE
fix(frontend): deadline every BFF -> monolith and client fetch call

### DIFF
--- a/services/frontend/workspace/src/lib/auth/fetch.ts
+++ b/services/frontend/workspace/src/lib/auth/fetch.ts
@@ -9,13 +9,22 @@ export type AuthFetchOptions = {
   body?: unknown;
   requireAuth?: boolean;
   cache?: RequestCache;
+  /**
+   * Client-side hard deadline. The BFF -> monolith path also carries a
+   * 15s gRPC deadline (lib/grpc.ts), so 20s here gives the server the full
+   * budget plus a small overhead. Without this, a stuck fetch leaves the
+   * UI on its loading spinner forever.
+   */
+  timeoutMs?: number;
 };
+
+const DEFAULT_TIMEOUT_MS = 20_000;
 
 export async function authFetch<T = unknown>(
   url: string,
   options: AuthFetchOptions = {}
 ): Promise<T> {
-  const { method = "GET", body, requireAuth = true, cache } = options;
+  const { method = "GET", body, requireAuth = true, cache, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
 
   if (requireAuth && !useAuthStore.getState().userId) {
     throw new AppError("UNAUTHORIZED", "ログインしてください", 401);
@@ -26,6 +35,9 @@ export async function authFetch<T = unknown>(
     headers["Content-Type"] = "application/json";
   }
 
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
   let res: Response;
   try {
     res = await fetch(url, {
@@ -33,14 +45,20 @@ export async function authFetch<T = unknown>(
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       cache,
+      signal: controller.signal,
     });
   } catch (cause) {
+    // AbortError = client-side timeout; surface as NETWORK so the caller
+    // shows the same "接続を確認してください" hint and stops the spinner
+    // instead of hanging indefinitely.
     throw new AppError(
       "NETWORK",
       "ネットワーク接続を確認してください",
       undefined,
       cause
     );
+  } finally {
+    clearTimeout(timeoutHandle);
   }
 
   if (!res.ok) {

--- a/services/frontend/workspace/src/lib/grpc.ts
+++ b/services/frontend/workspace/src/lib/grpc.ts
@@ -23,6 +23,11 @@ import { FootprintsService } from "@/stub/footprints/v1/footprints_service_pb";
 const transport = createGrpcTransport({
   // FALLBACK: Uses localhost when MONOLITH_URL is not configured
   baseUrl: process.env.MONOLITH_URL || "http://localhost:9001",
+  // Every non-streaming BFF call inherits this deadline. Without it a
+  // hung monolith call blocks the BFF route forever, which the UI then
+  // observes as a permanently-spinning loading state. Streaming routes
+  // (messaging/stream) opt out by passing a per-call signal.
+  defaultTimeoutMs: 15_000,
 });
 
 export const identityClient = createClient(IdentityService, transport);


### PR DESCRIPTION
## Status

Draft → Ready. Insurance against the reported "home feed spinner never resolves" symptom.

## Reported symptom

> 左ペインのブックマークを踏んでホームに戻ろうとするとリストが表示できなくなってるようです
> 読み込み中のスピナーが永遠に回る

## Why the UI can hang forever today

The only way the home page shows a permanent \`読み込み中…\` is if \`fetchInitial\` never resolves — usePaginatedFetch transitions \`loading=false\` from either \`then\` or \`catch\`, so a stuck promise leaves \`initialized=false, loading=true\` forever.

Two places had no deadline:

- **lib/grpc.ts** — \`createGrpcTransport\` had no \`defaultTimeoutMs\`. Every non-streaming BFF gRPC call could wait indefinitely for a stalled monolith.
- **lib/auth/fetch.ts** — \`authFetch\` had no \`AbortController\`. A stalled BFF route left the client waiting indefinitely.

I could not reproduce the specific hang in headless Chrome across multiple viewport / navigation shapes (mobile + desktop, Link nav + browser back + goto), so this PR does not claim to fix the root cause. It closes the failure mode where the UI is stuck with no user-visible recovery path.

## Change

**\`lib/grpc.ts\`**: pass \`defaultTimeoutMs: 15_000\` to \`createGrpcTransport\`. Streaming routes (messaging/stream) opt out today by passing their own \`signal\`, so no regression there.

**\`lib/auth/fetch.ts\`**: wrap the underlying fetch in an \`AbortController\` with a 20s default (configurable via new \`timeoutMs\` option). The 5s slack over the gRPC deadline is server budget + overhead. AbortError surfaces as the existing \`NETWORK\` \`AppError\`, which the caller already handles by stopping the spinner and rendering \`読み込みに失敗しました\`.

## Effect on the reported symptom

Whatever the underlying stall is, after 20s the caller receives \`AppError("NETWORK", ...)\`. \`usePaginatedFetch\` sets \`error\`, \`loading=false\`, and the home page renders "読み込みに失敗しました" — which is retryable, unlike the spinner.

## What this does NOT fix

- Root cause of the stall (still unknown; not reproduced in headless).
- Home page \`useEffect\` fires \`fetchInitial\` twice on initial mount in production build (visible in puppet logs). Being sent in a follow-up PR because it's a separate concern and this change is already independently useful.

## Verification

- \`tsc --noEmit\` clean, \`pnpm lint\` 0e/0w, \`pnpm build\` green
- Puppet against localhost (fresh login, mobile + desktop, 4 nav rounds) still returns \`/api/feed\` in <100ms in all rounds, so the 15/20s deadlines are far above the happy-path budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)