### PR TITLE
fix(messaging): dedicated PG connection for StreamEvents LISTEN loop

### DIFF
--- a/services/monolith/workspace/bin/grpc
+++ b/services/monolith/workspace/bin/grpc
@@ -59,6 +59,16 @@ Gruf.configure do |c|
   c.server_binding_url = ENV.fetch("GRPC_BIND_ADDRESS", "0.0.0.0:9001")
   c.interceptors.use(Interceptors::AccessLogInterceptor)
   c.interceptors.use(Interceptors::AuthenticationInterceptor)
+
+  # HTTP/2 concurrent-streams cap on the server side. The gRPC gem's
+  # default (100) sounds comfortable but a long-lived server-streaming
+  # RPC (messaging StreamEvents) combined with the frontend Node.js gRPC
+  # client's connection-reuse behaviour wedged every subsequent unary
+  # RPC on the same connection in puppet. Lifting the cap gives the
+  # mixed workload room to breathe.
+  c.server_options = {
+    "grpc.max_concurrent_streams" => 1024,
+  }
   # c.services.clear
 end
 

--- a/services/monolith/workspace/slices/footprints/grpc/footprints_handler.rb
+++ b/services/monolith/workspace/slices/footprints/grpc/footprints_handler.rb
@@ -56,7 +56,7 @@ module Footprints
           next nil unless profile
 
           ::Footprints::V1::Footprint.new(
-            visitor: profile,
+            visitor: present_profile(profile),
             last_visited_at: to_proto_ts(row[:last_visited_at]),
             is_unread: row[:is_unread],
             visit_count: row[:visit_count]
@@ -83,6 +83,26 @@ module Footprints
       end
 
       private
+
+      # Same Struct→proto fix as PR #770 / #791. Footprint carries a
+      # single profile.v1.Profile field (visitor); the earlier sweep grep
+      # on `profiles:` missed it because the field is singular.
+      # nil-safe: ProfilePresenter.to_proto returns nil for nil input.
+      def present_profile(profile)
+        return nil unless profile
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
+      end
 
       def get_profile
         @get_profile ||= Profile::Slice["use_cases.get_profile"]

--- a/services/monolith/workspace/slices/messaging/grpc/messaging_handler.rb
+++ b/services/monolith/workspace/slices/messaging/grpc/messaging_handler.rb
@@ -177,24 +177,43 @@ module Messaging
         viewer = current_user_id
         channel = "messaging_user_#{viewer}"
 
+        # Open a dedicated PG connection for the LISTEN loop instead of
+        # borrowing a Sequel-pool slot for the lifetime of the subscription.
+        # `db.synchronize` used to hold the slot for the whole loop; every
+        # open SSE subscription then locked up one of the pool's
+        # connections indefinitely, and any other RPC that needed SQL
+        # (login, feed, ...) would block waiting on the pool once the
+        # slots were saturated — which puppet reproduced as a total
+        # server hang after a single /messages visit.
         db = messaging_repo.send(:thread_records).dataset.db
+        opts = db.opts
+        conn = PG.connect(
+          host: opts[:host] || "localhost",
+          port: opts[:port] || 5432,
+          dbname: opts[:database],
+          user: opts[:user],
+          password: opts[:password]
+        )
 
-        db.synchronize do |conn|
+        begin
           quoted_channel = conn.escape_identifier(channel)
           conn.async_exec("LISTEN #{quoted_channel}")
+          loop do
+            conn.wait_for_notify(0.5) do |_chan, _pid, payload|
+              event = parse_payload_to_event(payload)
+              yield event if event
+            end
+          end
+        ensure
           begin
-            loop do
-              conn.wait_for_notify(0.5) do |_chan, _pid, payload|
-                event = parse_payload_to_event(payload)
-                yield event if event
-              end
-            end
-          ensure
-            begin
-              conn.async_exec("UNLISTEN #{quoted_channel}")
-            rescue StandardError
-              # connection may already be in error state, ignore
-            end
+            conn.async_exec("UNLISTEN #{quoted_channel}")
+          rescue StandardError
+            # connection may already be in error state, ignore
+          end
+          begin
+            conn.close
+          rescue StandardError
+            # already closed, ignore
           end
         end
       end

--- a/services/monolith/workspace/slices/notifications/grpc/notification_handler.rb
+++ b/services/monolith/workspace/slices/notifications/grpc/notification_handler.rb
@@ -43,7 +43,7 @@ module Notifications
             type: type_to_enum(row.type),
             target_resource_id: row.target_resource_id,
             actor_count: row.actor_count,
-            latest_actor: result[:profiles_by_actor_id][row.latest_actor_id],
+            latest_actor: present_profile(result[:profiles_by_actor_id][row.latest_actor_id]),
             latest_event_at: time_to_timestamp(row.latest_event_at),
             read_at: row.read_at ? time_to_timestamp(row.read_at) : nil,
             target_post_id: row.target_post_id || ""
@@ -108,6 +108,26 @@ module Notifications
       end
 
       private
+
+      # Same Struct→proto fix as PR #770 / #791. Notifications carries a
+      # single profile.v1.Profile field (latest_actor) rather than a
+      # repeated one, so the earlier sweep grep on `profiles:` missed it.
+      # nil-safe: ProfilePresenter.to_proto returns nil for nil input.
+      def present_profile(profile)
+        return nil unless profile
+        ::Profile::Presenters::ProfilePresenter.to_proto(
+          profile,
+          role: role_for(profile.account_id)
+        )
+      end
+
+      def role_for(account_id)
+        identity_user_repo.find_by_id(account_id)&.role || 0
+      end
+
+      def identity_user_repo
+        @identity_user_repo ||= ::Identity::Slice["repositories.user_repository"]
+      end
 
       def preferences_to_proto(prefs)
         ::Notifications::V1::NotificationPreferences.new(


### PR DESCRIPTION
## Status

Draft → Ready. Partial fix for the reported "home feed spinner永久" symptom.

## Reported symptom

> 左ペインのブックマークを踏んでホームに戻ろうとするとリストが表示できなくなってるようです
> 中央フィード (投稿一覧) のスピナーが永遠に回る

## Root cause chain (partial)

Reproduced with puppet: open /messages → sidebar bookmark → sidebar home → central feed enters the "読み込み中" spinner. On the current authFetch 20s timeout branch (\`fix/home-feed-loading-insurance\`) it eventually flips to "読み込みに失敗しました", confirming the fetch is stuck waiting for a response the server never sends.

The messaging \`StreamEvents\` handler was:

```ruby
db.synchronize do |conn|
  conn.async_exec("LISTEN ...")
  loop do
    conn.wait_for_notify(0.5) do |...|
      yield event
    end
  end
end
```

\`db.synchronize\` borrows a Sequel connection-pool slot and holds it for the whole block. Every open SSE subscriber therefore locked one pool slot indefinitely, and once the pool ran out, every other RPC that needed SQL (login, feed, ...) blocked waiting on the pool.

## Fix

- **Dedicated PG connection per subscriber.** Open a raw \`PG.connect\` for the LISTEN loop, don't touch the Sequel pool. \`ensure\` closes it on exit.
- **Lift \`grpc.max_concurrent_streams\`** to 1024 on the gruf server so the HTTP/2 stream cap can't become the next bottleneck.

## Verification status (WIP)

- \`bundle exec rspec spec/slices/messaging\` still green (no new specs; the block-level shape doesn't change)
- Fresh single-instance monolith + curl login: 0.35s
- Puppet SSE-then-home scenario: **still reproduces the spinner** on the first affected round
- Client-side \`authFetch\` 20s timeout (already in main via #807 + follow-ups) flips the stuck spinner to "読み込みに失敗しました" so users are recoverable rather than stuck forever

More investigation is still needed on why the frontend Node.js HTTP/2 client keeps unary RPCs pending after a streaming call, which suggests the wedge also lives in \`@connectrpc/connect-node\` or the transport pool.

## Follow-up ideas

- Split transports on frontend so streaming and unary run on separate HTTP/2 connections (already tried on \`fix/home-feed-loading-insurance\`; effect inconclusive because monolith side was still wedging)
- Detect gRPC client cancel inside the LISTEN loop and break early
- Investigate whether Node.js \`http2\` client reuse is the wedge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved live event streaming reliability under heavier usage.
  * Notification and footprint views now show richer actor/visitor profile details, including role information when available.

* **Bug Fixes**
  * Fixed cases where profile data could appear incomplete or unformatted in notifications and footprints.
  * Reduced the chance of streaming interruptions during long-running event subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->