### PR TITLE
fix(messaging): swap SSE for polling to end the home-feed connection wedge

### DIFF
--- a/services/frontend/workspace/src/app/api/messaging/stream/route.ts
+++ b/services/frontend/workspace/src/app/api/messaging/stream/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { messagingClient } from "@/lib/grpc";
+import { messagingStreamingClient } from "@/lib/grpc";
 import { buildGrpcHeaders } from "@/lib/request";
 import { requireAuth } from "@/lib/api-helpers";
 import type { Event } from "@/stub/messaging/v1/messaging_service_pb";
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest) {
     async start(controller) {
       const enc = new TextEncoder();
       try {
-        for await (const event of messagingClient.streamEvents(
+        for await (const event of messagingStreamingClient.streamEvents(
           {},
           { headers, signal: req.signal }
         )) {

--- a/services/frontend/workspace/src/app/page.tsx
+++ b/services/frontend/workspace/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Tabs, type TabItem } from "@/components/ui/tab";
 import { Button } from "@/components/ui/button";
 import { PostCardBinding } from "@/modules/post/components/PostCardBinding";
@@ -32,8 +32,20 @@ export default function HomePage() {
     reset,
   } = useFeed({ filter, prefecture });
 
-  // Re-fetch when filter or prefecture changes.
+  // Re-fetch when filter or prefecture actually change.
+  //
+  // Guard against duplicate fetches on initial mount: production builds
+  // running under Next.js/Turbopack have been observed firing this effect
+  // twice for the same (filter, prefecture) tuple, which spawns a second
+  // request while the first is still in flight (usePaginatedFetch resets
+  // its refs on `reset()`, defeating its own gate). The fingerprint check
+  // skips the second invocation while still letting a real tab switch or
+  // profile-loaded prefecture refresh the list.
+  const lastFetchFingerprint = useRef<string>("");
   useEffect(() => {
+    const fingerprint = `${filter}::${prefecture ?? ""}`;
+    if (lastFetchFingerprint.current === fingerprint) return;
+    lastFetchFingerprint.current = fingerprint;
     reset();
     fetchInitial();
     // fetchInitial / reset are stable from usePaginatedFetch; we intentionally depend on

--- a/services/frontend/workspace/src/lib/grpc.ts
+++ b/services/frontend/workspace/src/lib/grpc.ts
@@ -19,16 +19,22 @@ import { FootprintsService } from "@/stub/footprints/v1/footprints_service_pb";
 // In server environment (Next.js API Routes), we connect to Monolith directly.
 // Monolith is at 'http://monolith:9001' or 'http://localhost:9001' depending on Docker/Local.
 // We should use ENV.
-// standard gRPC server requires createGrpcTransport
-const transport = createGrpcTransport({
-  // FALLBACK: Uses localhost when MONOLITH_URL is not configured
-  baseUrl: process.env.MONOLITH_URL || "http://localhost:9001",
-  // Every non-streaming BFF call inherits this deadline. Without it a
-  // hung monolith call blocks the BFF route forever, which the UI then
-  // observes as a permanently-spinning loading state. Streaming routes
-  // (messaging/stream) opt out by passing a per-call signal.
-  defaultTimeoutMs: 15_000,
-});
+// Two transports on purpose:
+// - `transport` for regular (unary) RPCs
+// - `streamingTransport` for long-lived server-streaming RPCs
+//   (e.g. /api/messaging/stream)
+//
+// @connectrpc/connect-node opens one HTTP/2 connection per transport
+// instance and multiplexes streams on it. If a long-lived SSE stream
+// shares the same transport as unary RPCs, the SSE stream keeps the
+// connection open forever and can wedge subsequent unary RPCs (feed,
+// follow, etc.) so they never receive response frames — puppet
+// reproduces this after opening /messages then navigating back home.
+// Isolating the streaming client onto its own connection keeps the
+// unary path free.
+const baseUrl = process.env.MONOLITH_URL || "http://localhost:9001";
+const transport = createGrpcTransport({ baseUrl });
+const streamingTransport = createGrpcTransport({ baseUrl });
 
 export const identityClient = createClient(IdentityService, transport);
 
@@ -61,6 +67,9 @@ export const discoveryClient = createClient(DiscoveryService, transport);
 
 // Messaging domain client (messaging.v1)
 export const messagingClient = createClient(MessagingService, transport);
+// Server-streaming client. `/api/messaging/stream` uses this so the long-poll
+// SSE keeps its own HTTP/2 connection and never blocks unary RPCs.
+export const messagingStreamingClient = createClient(MessagingService, streamingTransport);
 
 // Footprints domain client (footprints.v1)
 export const footprintsClient = createClient(FootprintsService, transport);

--- a/services/frontend/workspace/src/modules/messaging/providers/MessagingStreamProvider.tsx
+++ b/services/frontend/workspace/src/modules/messaging/providers/MessagingStreamProvider.tsx
@@ -10,33 +10,77 @@ export function MessagingStreamProvider({ children }: { children: React.ReactNod
 
   useEffect(() => {
     if (!useAuthStore.getState().userId) return;
-    const es = new EventSource("/api/messaging/stream");
-    es.onmessage = (msg) => {
+
+    // fetch + AbortController rather than EventSource: the browser's
+    // EventSource.close() does not synchronously abort the underlying HTTP
+    // request. When this provider unmounts (route change away from
+    // /messages), a stale server-side gRPC stream was continuing to hold
+    // its slot on the frontend Node.js -> monolith HTTP/2 connection,
+    // wedging the next unary RPC on the same route (feed, follow, ...) —
+    // reproducible in puppet as a permanent-loading spinner. Aborting the
+    // fetch propagates through req.signal so the /api/messaging/stream
+    // route drops its for-await loop and the backend stream ends.
+    const controller = new AbortController();
+
+    const handle = async () => {
+      let res: Response;
       try {
-        const payload = JSON.parse(msg.data) as StreamEventPayload;
-        if (payload.type === "message") {
-          mutate(
-            (key) =>
-              typeof key === "string" &&
-              key.startsWith(`/api/messaging/threads/${payload.data.threadId}/messages`)
-          );
-          mutate("/api/messaging/threads");
-          mutate("/api/messaging/unread-count");
-        } else if (payload.type === "read_state") {
-          mutate(
-            (key) =>
-              typeof key === "string" &&
-              key.startsWith(`/api/messaging/threads/${payload.data.threadId}/messages`)
-          );
-          mutate("/api/messaging/threads");
-        } else if (payload.type === "typing") {
-          window.dispatchEvent(new CustomEvent("messaging:typing", { detail: payload }));
+        res = await fetch("/api/messaging/stream", { signal: controller.signal });
+      } catch {
+        // SILENT: aborted before response
+        return;
+      }
+      if (!res.body) return;
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) return;
+          buffer += decoder.decode(value, { stream: true });
+          for (;;) {
+            const boundary = buffer.indexOf("\n\n");
+            if (boundary < 0) break;
+            const frame = buffer.slice(0, boundary);
+            buffer = buffer.slice(boundary + 2);
+            const dataLine = frame.split("\n").find((line) => line.startsWith("data: "));
+            if (!dataLine) continue;
+            let payload: StreamEventPayload;
+            try {
+              payload = JSON.parse(dataLine.slice(6)) as StreamEventPayload;
+            } catch {
+              // SILENT: 不正な payload は読み飛ばす
+              continue;
+            }
+            if (payload.type === "message") {
+              mutate(
+                (key) =>
+                  typeof key === "string" &&
+                  key.startsWith(`/api/messaging/threads/${payload.data.threadId}/messages`)
+              );
+              mutate("/api/messaging/threads");
+              mutate("/api/messaging/unread-count");
+            } else if (payload.type === "read_state") {
+              mutate(
+                (key) =>
+                  typeof key === "string" &&
+                  key.startsWith(`/api/messaging/threads/${payload.data.threadId}/messages`)
+              );
+              mutate("/api/messaging/threads");
+            } else if (payload.type === "typing") {
+              window.dispatchEvent(new CustomEvent("messaging:typing", { detail: payload }));
+            }
+          }
         }
       } catch {
-        // SILENT: 不正な payload は読み飛ばす
+        // SILENT: reader aborted
       }
     };
-    return () => es.close();
+
+    void handle();
+
+    return () => controller.abort();
   }, [mutate]);
 
   return <>{children}</>;

--- a/services/frontend/workspace/src/modules/messaging/providers/MessagingStreamProvider.tsx
+++ b/services/frontend/workspace/src/modules/messaging/providers/MessagingStreamProvider.tsx
@@ -3,84 +3,40 @@
 import { useEffect } from "react";
 import { useSWRConfig } from "swr";
 import { useAuthStore } from "@/stores/authStore";
-import type { StreamEventPayload } from "../types";
+
+/**
+ * Poll-based refresh for messaging state.
+ *
+ * Historically this provider held a server-streaming SSE subscription
+ * (`/api/messaging/stream`) so the client would push-refresh on incoming
+ * messages, reads, and typing signals. In practice the abort path of
+ * that stream never propagated cleanly through the Node.js gRPC client
+ * on the BFF: puppet reproduced the symptom where opening /messages
+ * once left a lingering HTTP/2 stream on the frontend→monolith
+ * connection, and every subsequent unary RPC (feed, follow, ...) sat
+ * waiting for a response the server never sent — the user's central
+ * feed spinner.
+ *
+ * We drop the SSE and poll a lightweight endpoint every 6 seconds
+ * instead. It trades sub-second delivery for guaranteed cleanup on
+ * unmount. Typing indicators are gone as a consequence; that feature
+ * was best-effort and can come back once we have a working push
+ * channel that survives cancellation.
+ */
+const POLL_INTERVAL_MS = 6_000;
 
 export function MessagingStreamProvider({ children }: { children: React.ReactNode }) {
   const { mutate } = useSWRConfig();
 
   useEffect(() => {
     if (!useAuthStore.getState().userId) return;
-
-    // fetch + AbortController rather than EventSource: the browser's
-    // EventSource.close() does not synchronously abort the underlying HTTP
-    // request. When this provider unmounts (route change away from
-    // /messages), a stale server-side gRPC stream was continuing to hold
-    // its slot on the frontend Node.js -> monolith HTTP/2 connection,
-    // wedging the next unary RPC on the same route (feed, follow, ...) —
-    // reproducible in puppet as a permanent-loading spinner. Aborting the
-    // fetch propagates through req.signal so the /api/messaging/stream
-    // route drops its for-await loop and the backend stream ends.
-    const controller = new AbortController();
-
-    const handle = async () => {
-      let res: Response;
-      try {
-        res = await fetch("/api/messaging/stream", { signal: controller.signal });
-      } catch {
-        // SILENT: aborted before response
-        return;
-      }
-      if (!res.body) return;
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      try {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) return;
-          buffer += decoder.decode(value, { stream: true });
-          for (;;) {
-            const boundary = buffer.indexOf("\n\n");
-            if (boundary < 0) break;
-            const frame = buffer.slice(0, boundary);
-            buffer = buffer.slice(boundary + 2);
-            const dataLine = frame.split("\n").find((line) => line.startsWith("data: "));
-            if (!dataLine) continue;
-            let payload: StreamEventPayload;
-            try {
-              payload = JSON.parse(dataLine.slice(6)) as StreamEventPayload;
-            } catch {
-              // SILENT: 不正な payload は読み飛ばす
-              continue;
-            }
-            if (payload.type === "message") {
-              mutate(
-                (key) =>
-                  typeof key === "string" &&
-                  key.startsWith(`/api/messaging/threads/${payload.data.threadId}/messages`)
-              );
-              mutate("/api/messaging/threads");
-              mutate("/api/messaging/unread-count");
-            } else if (payload.type === "read_state") {
-              mutate(
-                (key) =>
-                  typeof key === "string" &&
-                  key.startsWith(`/api/messaging/threads/${payload.data.threadId}/messages`)
-              );
-              mutate("/api/messaging/threads");
-            } else if (payload.type === "typing") {
-              window.dispatchEvent(new CustomEvent("messaging:typing", { detail: payload }));
-            }
-          }
-        }
-      } catch {
-        // SILENT: reader aborted
-      }
+    const tick = () => {
+      mutate("/api/messaging/unread-count");
+      mutate("/api/messaging/threads");
     };
-
-    void handle();
-
-    return () => controller.abort();
+    tick();
+    const handle = setInterval(tick, POLL_INTERVAL_MS);
+    return () => clearInterval(handle);
   }, [mutate]);
 
   return <>{children}</>;


### PR DESCRIPTION
## Status

Draft → Ready. Root fix for the reported "central feed spinner永久" symptom.

## Reported symptom

> 左ペインのブックマークを踏んでホームに戻ろうとするとリストが表示できなくなってるようです
> 中央フィード (投稿一覧) のスピナーが永遠に回る

## What was actually happening

Confirmed with a puppet probe watching TCP connections between the frontend Node.js server and monolith \`:9001\`:

| Step | TCP established to :9001 |
|---|---|
| baseline | 0 |
| after login | 2 (unary + streaming transports) |
| after visiting /messages | **4** (SSE stream from \`MessagingStreamProvider\` opens) |
| after sidebar → /bookmarks | **4** (SSE stream did not close) |
| after sidebar → / (home) | **4** |
| after browser.close() | **still 4** (stream never cleaned up) |

Once the stream lived on the shared HTTP/2 connection, subsequent unary RPCs (feed, follow, ...) queued and never received response frames — the user's central feed spinner.

The cancellation path was ostensibly wired: the BFF passed \`req.signal\` into \`messagingStreamingClient.streamEvents(...)\`, and I rewrote the client from \`EventSource\` to \`fetch\` + \`AbortController\`. Neither actually cleared the stream — \`for await\` in the BFF route stayed pending, and \`@connectrpc/connect-node\`'s HTTP/2 client did not release its slot.

## Fix

Rewrite \`MessagingStreamProvider\` as a plain SWR-key revalidation on a 6-second interval. No SSE, no \`fetch\` stream, no server-streaming RPC. \`clearInterval\` on unmount is a guaranteed cleanup path.

After the change, the same puppet probe shows:

| Step | TCP established to :9001 |
|---|---|
| baseline | 0 |
| after login | 2 |
| after visiting /messages | **2** |
| after sidebar → /bookmarks | 2 |
| after sidebar → / (home) | 2 |
| after browser.close() | 2 (idle keep-alive on the two transports) |

Home renders normally, main text shows the seeded posts (\`dogfood r6: 今日も元気 🌷\`), and a follow-up curl login continues to return in ~0.3s instead of stalling.

## Tradeoff

Typing indicators and sub-second message push delivery are gone. Both were best-effort and can come back once the streaming API has a working cancellation story. \`/api/messaging/stream\` route is left intact for now (nothing calls it) so this PR stays scoped to the smallest change that unwedges the connection.

## Combined with earlier commits on this branch

This branch also carries:
- \`fix(frontend): deadline every BFF -> monolith and client fetch call\` — 20s authFetch AbortController + 15s gRPC deadline (later reverted to avoid wedging login itself)
- \`fix(frontend): dedupe home page feed effect fire\` — fingerprint check on the home useEffect to avoid a double-fire on first mount
- \`fix(frontend): isolate SSE messaging stream from unary RPC connection\` — split transport instances so streaming and unary run on distinct HTTP/2 connections (belt-and-braces; the SSE removal is the real fix)

## Verification

- \`tsc --noEmit\` clean, \`pnpm lint\` 0e/0w, \`pnpm build\` green
- Puppet probe as documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate page refreshes when the same filter and location are applied, reducing unnecessary reloads and duplicate data fetches.
  - Improved messaging updates by switching to a more reliable refresh approach, helping unread counts and thread lists stay current.
  - Updated the message stream handling so live updates continue to work smoothly without interrupting other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->