### PR TITLE
chore(services/monolith/workspace): drop pnpm packageManager field

### DIFF
--- a/services/monolith/workspace/package.json
+++ b/services/monolith/workspace/package.json
@@ -4,6 +4,5 @@
   "type": "module",
   "dependencies": {
     "hanami-assets": "^2.3.3"
-  },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
+  }
 }


### PR DESCRIPTION
## Why

The monolith workspace actually uses **npm** — `bin/setup` runs `npm install` and the lockfile is `package-lock.json`. The `packageManager: pnpm@...` entry in `package.json` was introduced incidentally in 7dfcb552 (`feat(social)`) and never matched the toolchain; the Docker build is pure Ruby/bundler and never invokes pnpm.

Renovate kept tracking that field and its pnpm 11 major bump (#790) failed in `corepack use pnpm@11`, surfacing as a `renovate/artifacts` failure with no real target. Removing the field aligns the manifest with the npm toolchain and stops Renovate from proposing pnpm upgrades for this workspace.

Supersedes and closes #790.

## Verification

- `node -e "require('./package.json')"` → valid JSON, `packageManager` removed, other keys intact
- `npm install --package-lock-only` → `up to date`, no change to `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the package manager metadata from the workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->